### PR TITLE
依赖相关问题

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ markdown==3.8.2
 Jinja2==3.1.6
 nuitka==2.7.12
 pillow==11.3.0
+packaging==25.0


### PR DESCRIPTION
在 app/core/task_manager.py 文件中，第 31 行使用了 packaging 模块。其并非标准库，因此需要确保它被包含在项目依赖中。