### PR TITLE
Add dedicated About page and move "其他设置" out of Settings

### DIFF
--- a/frontend/src/components/AppLayout.vue
+++ b/frontend/src/components/AppLayout.vue
@@ -51,6 +51,7 @@ import {
   CalendarOutlined,
   ControlOutlined,
   DatabaseOutlined,
+  ExclamationCircleOutlined,
   FileSearchOutlined,
   FileTextOutlined,
   HistoryOutlined,
@@ -103,6 +104,7 @@ const bottomMenuItems = [
   { key: '/history', label: '历史记录', icon: icon(HistoryOutlined) },
   { key: '/logs', label: '日志', icon: icon(FileSearchOutlined) },
   { key: '/settings', label: '设置', icon: icon(SettingOutlined) },
+  { key: '/about', label: '关于', icon: icon(ExclamationCircleOutlined) },
 ]
 
 const allItems = computed(() => [

--- a/frontend/src/components/devtools/QuickNavPage.vue
+++ b/frontend/src/components/devtools/QuickNavPage.vue
@@ -86,6 +86,7 @@ const commonRoutes = [
   { path: '/queue', title: '调度队列' },
   { path: '/settings', title: '设置' },
   { path: '/logs', title: '日志' },
+  { path: '/about', title: '关于' },
 ]
 
 // 导航到指定路由

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -128,6 +128,12 @@ const routes = [
     component: () => import('../views/Logs.vue'),
     meta: { title: '日志查看' },
   },
+  {
+    path: '/about',
+    name: 'About',
+    component: () => import('../views/about/index.vue'),
+    meta: { title: '关于' },
+  },
 ]
 
 const router = createRouter({

--- a/frontend/src/views/about/index.vue
+++ b/frontend/src/views/about/index.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { Service, type VersionOut } from '@/api'
+import { getLogger } from '@/utils/logger'
+import TabOthers from '@/views/setting/TabOthers.vue'
+
+const logger = getLogger('关于')
+const version = (import.meta as any).env?.VITE_APP_VERSION || '获取版本失败！'
+const backendUpdateInfo = ref<VersionOut | null>(null)
+
+// 后端版本
+const getBackendVersion = async () => {
+  try {
+    backendUpdateInfo.value = await Service.getGitVersionApiInfoVersionPost()
+  } catch (e) {
+    logger.error('获取后端版本失败', e)
+  }
+}
+
+onMounted(() => {
+  getBackendVersion()
+})
+</script>
+
+<template>
+  <div class="about-container">
+    <div class="about-header">
+      <h1 class="page-title">关于</h1>
+    </div>
+    <div class="about-content">
+      <TabOthers :version="version" :backend-update-info="backendUpdateInfo" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.about-container {
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+
+.about-header {
+  margin-bottom: 16px;
+  padding: 0 4px;
+}
+
+.page-title {
+  margin: 0;
+  font-size: 32px;
+  font-weight: 700;
+  color: var(--ant-color-text);
+  background: linear-gradient(135deg, var(--ant-color-primary), var(--ant-color-primary-hover));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.about-content {
+  background: var(--ant-color-bg-container);
+  border-radius: 12px;
+  width: 100%;
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.about-content :deep(.tab-content) {
+  padding: 24px;
+  width: 100%;
+}
+</style>

--- a/frontend/src/views/setting/index.vue
+++ b/frontend/src/views/setting/index.vue
@@ -8,7 +8,6 @@ import type { SelectValue } from 'ant-design-vue/es/select'
 import type { GlobalConfig } from '@/api'
 import { useSettingsApi } from '@/composables/useSettingsApi'
 import { useUpdateChecker } from '@/composables/useUpdateChecker.ts'
-import { Service, type VersionOut } from '@/api'
 import { getLogger } from '@/utils/logger'
 
 const logger = getLogger('设置')
@@ -18,7 +17,6 @@ import TabBasic from './TabBasic.vue'
 import TabFunction from './TabFunction.vue'
 import TabNotify from './TabNotify.vue'
 import TabAdvanced from './TabAdvanced.vue'
-import TabOthers from './TabOthers.vue'
 
 const router = useRouter()
 const { themeMode, themeColor, themeColors, setThemeMode, setThemeColor } = useTheme()
@@ -33,8 +31,6 @@ const {
 
 // 活动标签
 const activeKey = ref('basic')
-const version = (import.meta as any).env?.VITE_APP_VERSION || '获取版本失败！'
-const backendUpdateInfo = ref<VersionOut | null>(null)
 
 // 设置数据 - 从API获取，不再使用硬编码初值
 const settings = reactive<GlobalConfig>({})
@@ -228,14 +224,6 @@ const checkUpdate = async () => {
 
 // onUpdateConfirmed 不再需要，由全局UpdateModal管理
 
-// 后端版本
-const getBackendVersion = async () => {
-  try {
-    backendUpdateInfo.value = await Service.getGitVersionApiInfoVersionPost()
-  } catch (e) {
-    logger.error('获取后端版本失败', e)
-  }
-}
 
 // 通知测试
 const testingNotify = ref(false)
@@ -255,7 +243,6 @@ const testNotify = async () => {
 
 onMounted(() => {
   loadSettings()
-  getBackendVersion()
 })
 </script>
 
@@ -284,9 +271,6 @@ onMounted(() => {
         </a-tab-pane>
         <a-tab-pane key="advanced" tab="高级设置">
           <TabAdvanced :go-to-logs="goToLogs" :open-dev-tools="openDevTools" />
-        </a-tab-pane>
-        <a-tab-pane key="others" tab="其他设置">
-          <TabOthers :version="version" :backend-update-info="backendUpdateInfo" />
         </a-tab-pane>
       </a-tabs>
     </div>


### PR DESCRIPTION
### Motivation
- The settings page contained an "其他设置" tab that is conceptually an "About"/project-info page; this change separates that content into a dedicated left-side route to improve discoverability and UX.

### Description
- Add a new `frontend/src/views/about/index.vue` view that reuses existing `TabOthers` content and fetches backend version via `Service.getGitVersionApiInfoVersionPost`.
- Register a new `/about` route in `frontend/src/router/index.ts` and add a bottom sidebar entry using `ExclamationCircleOutlined` in `frontend/src/components/AppLayout.vue`.
- Remove the "其他设置" tab and related imports/backend-version logic from `frontend/src/views/setting/index.vue` so the settings page no longer shows that tab.
- Update developer quick-nav at `frontend/src/components/devtools/QuickNavPage.vue` to include the `/about` shortcut.

### Testing
- Started the frontend dev server with `yarn dev` and confirmed Vite served the app (`http://localhost:5173`) and `curl -I http://localhost:5173` returned `200 OK`.
- Attempted to run the Playwright script to capture `/about`, but Chromium crashed in the container causing the Playwright run to fail with a segfault; screenshot was not produced. 
- Running the Electron dev watcher failed due to a missing native dependency (`libatk-1.0.so.0`), which prevented the Electron process from launching.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698946e73acc832f966019b57a17e44a)