### PR TITLE
在 MAA 用户标签前添加“人工排查未通过”红色标签

### DIFF
--- a/frontend/src/components/ScriptTable.vue
+++ b/frontend/src/components/ScriptTable.vue
@@ -92,6 +92,9 @@
 
                         <!-- 用户详细信息 - MAA脚本用户 -->
                         <div v-if="script.type === 'MAA'" class="user-info-tags">
+                          <a-tag v-if="user.Data?.IfPassCheck === false" class="info-tag" color="red">
+                            人工排查未通过
+                          </a-tag>
                           <!-- 剿灭模式 -->
                           <a-tag v-if="
                             user.Info.Annihilation &&


### PR DESCRIPTION
### Motivation
- 在前端 MAA 用户管理页中，当 `Data.IfPassCheck` 为 `false` 时需要在所有标签最前面显示“人工排查未通过”以便用户快速识别未通过人工排查的账号。

### Description
- 在 `frontend/src/components/ScriptTable.vue` 的 MAA 用户标签渲染区域前插入了一个条件标签：当 `user.Data?.IfPassCheck === false` 时渲染一个红色的 `<a-tag>`，文本为“人工排查未通过”。

### Testing
- 尝试使用 Playwright 捕获页面截图以验证视觉效果，但因本地前端开发服务器不可达导致失败（`http://localhost:5173` 返回空响应），未能完成自动化可视化测试。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69899e4844b8832fa8109a208e7264ac)