### PR TITLE
fix(frontend): avoid Vue runtime errors when logging update state

### DIFF
--- a/frontend/src/components/UpdateModal.vue
+++ b/frontend/src/components/UpdateModal.vue
@@ -1,10 +1,21 @@
 <template>
-  <a-modal v-model:open="visible" :title="`发现新版本 ${latestVersion || ''}`" :width="800" :footer="null"
-    :mask-closable="false" :z-index="9999" class="update-modal">
+  <a-modal
+    v-model:open="visible"
+    :title="`发现新版本 ${latestVersion || ''}`"
+    :width="800"
+    :footer="null"
+    :mask-closable="false"
+    :z-index="9999"
+    class="update-modal"
+  >
     <div class="update-container">
       <!-- 更新内容展示 -->
       <div class="update-content">
-        <div ref="markdownContentRef" class="markdown-content" v-html="renderMarkdown(updateContent)"></div>
+        <div
+          ref="markdownContentRef"
+          class="markdown-content"
+          v-html="renderMarkdown(updateContent)"
+        ></div>
       </div>
 
       <!-- 操作按钮 -->
@@ -18,9 +29,14 @@
   </a-modal>
 
   <!-- 独立的下载窗口 -->
-  <UpdateDownloadModal v-model:visible="showDownloadModal" :latest-version="latestVersion" :update-data="updateData"
-    @completed="handleDownloadCompleted" @cancelled="handleDownloadCancelled"
-    @install-requested="handleInstallRequested" />
+  <UpdateDownloadModal
+    v-model:visible="showDownloadModal"
+    :latest-version="latestVersion"
+    :update-data="updateData"
+    @completed="handleDownloadCompleted"
+    @cancelled="handleDownloadCancelled"
+    @install-requested="handleInstallRequested"
+  />
 </template>
 
 <script setup lang="ts">
@@ -46,6 +62,7 @@ const emit = defineEmits<{
 
 // 内部状态
 const hasUpdate = ref(false)
+const markdownContentRef = ref<HTMLElement | null>(null)
 const showDownloadModal = ref(false)
 
 // 计算最新版本号
@@ -118,11 +135,12 @@ if (props.updateData && Object.keys(props.updateData).length > 0) {
 // 处理下载按钮点击
 const handleDownload = () => {
   logger.info('[UpdateModal] 点击下载按钮')
-  logger.info('[UpdateModal] 当前props:', {
-    updateData: props.updateData,
-    latestVersion: props.latestVersion,
-    visible: props.visible,
-  })
+
+  // 避免直接记录 Vue 响应式对象（Electron logger 在序列化 Proxy 时可能抛错）
+  logger.info(
+    `[UpdateModal] 当前状态: visible=${props.visible}, latestVersion=${props.latestVersion || 'unknown'}, updateSections=${Object.keys(props.updateData || {}).length}`
+  )
+
   // 关闭当前窗口，显示下载窗口
   visible.value = false
   showDownloadModal.value = true

--- a/frontend/src/views/setting/index.vue
+++ b/frontend/src/views/setting/index.vue
@@ -203,19 +203,15 @@ const openDevTools = () => (window as any).electronAPI?.openDevTools?.()
 // 更新检查 - 使用全局更新检查器
 const checkUpdate = async () => {
   logger.info('[Setting] 使用全局更新检查器进行手动检查')
-  logger.info('[Setting] 检查前状态:', {
-    updateVisible: updateVisible.value,
-    updateData: updateData.value,
-    latestVersion: latestVersion.value,
-  })
+  logger.info(
+    `[Setting] 检查前状态: updateVisible=${updateVisible.value}, latestVersion=${latestVersion.value || 'unknown'}, updateSections=${Object.keys(updateData.value || {}).length}`
+  )
 
   try {
     await globalCheckUpdate(false, true) // silent=false, forceCheck=true
-    logger.info('[Setting] 全局更新检查完成，状态:', {
-      updateVisible: updateVisible.value,
-      updateData: updateData.value,
-      latestVersion: latestVersion.value,
-    })
+    logger.info(
+      `[Setting] 全局更新检查完成: updateVisible=${updateVisible.value}, latestVersion=${latestVersion.value || 'unknown'}, updateSections=${Object.keys(updateData.value || {}).length}`
+    )
   } catch (error) {
     logger.error('[Setting] 全局更新检查失败:', error)
   }


### PR DESCRIPTION
### Motivation
- 修复在点击“下载更新”或在设置页手动检查更新时前端抛出的 Vue runtime 错误（日志中显示 `runtime-6`），导致 UI 无响应的问题。 
- 问题根因是把 Vue 的响应式对象/Proxy 直接传给 Electron 的 logger，序列化时触发运行时异常。 
- 需要最小化改动范围，只修复日志序列化相关的触发点以立即恢复更新流程可用性。 

### Description
- 在 `frontend/src/components/UpdateModal.vue` 中将原先直接记录 `props`（响应式对象）的 `logger.info` 调用替换为安全的字符串快照，记录 `visible`、`latestVersion` 和 `updateSections`，并补充声明了模板使用的 `markdownContentRef`。 
- 在 `frontend/src/views/setting/index.vue` 中将手动检查更新前后日志也改为安全的字符串快照，避免打印 `ref`/响应式对象。 
- 仅对上述文件做了格式化调整以满足本地 lint/ prettier 校验，未对其他文件做功能性改动。 

### Testing
- 运行了针对修改文件的 ESLint 检查 `yarn --cwd frontend eslint src/components/UpdateModal.vue src/views/setting/index.vue`，结果显示仅存在仓库中已有的规则（如 `vue/multi-word-component-names` 与 `v-html` 警告），与本次改动无关。 
- 使用 `yarn --cwd frontend prettier` 对修改文件做了格式化以修复样式类的 lint 报告，格式化成功。 
- 运行全仓 `yarn --cwd frontend lint` 会失败（仓库中存在大量既有 lint/解析问题），因此本 PR 仅执行并验证了对改动文件的静态检查。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b39383048832f9247f9bd20fe81db)