### PR TITLE
fix: 修复了历史记录搜索在非简中系统上失效的问题

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1488,12 +1488,12 @@ class AppConfig(GlobalConfig):
         history_index = await self.search_history(
             "DAILY", datetime.now(tz=UTC4).date(), datetime.now(tz=UTC4).date()
         )
-        if datetime.now(tz=UTC4).strftime("%Y年 %m月 %d日") not in history_index:
+        if datetime.now(tz=UTC4).strftime("%Y-%m-%d") not in history_index:
             return {}
         history_data = {
             k: await self.merge_statistic_info(v)
             for k, v in history_index[
-                datetime.now(tz=UTC4).strftime("%Y年 %m月 %d日")
+                datetime.now(tz=UTC4).strftime("%Y-%m-%d")
             ].items()
         }
         overview = {}
@@ -1501,9 +1501,9 @@ class AppConfig(GlobalConfig):
             index_data = data.get("index", [])
             if index_data:
                 last_proxy_date = max(
-                    datetime.strptime(_["date"], "%Y年%m月%d日 %H:%M:%S")
+                    datetime.strptime(_["date"], "%Y-%m-%d %H:%M:%S")
                     for _ in index_data
-                ).strftime("%Y年%m月%d日 %H:%M:%S")
+                ).strftime("%Y-%m-%d %H:%M:%S")
             else:
                 last_proxy_date = "暂无代理数据"
             proxy_times = len(data.get("index", []))
@@ -2028,11 +2028,11 @@ class AppConfig(GlobalConfig):
                         if "error_info" not in data:
                             data["error_info"] = {}
                         data["error_info"][
-                            actual_date.strftime("%Y年%m月%d日 %H:%M:%S")
+                            actual_date.strftime("%Y-%m-%d %H:%M:%S")
                         ] = single_data[key]
 
                     data["index"][actual_date] = {
-                        "date": actual_date.strftime("%Y年%m月%d日 %H:%M:%S"),
+                        "date": actual_date.strftime("%Y-%m-%d %H:%M:%S"),
                         "status": (
                             "DONE" if single_data[key] == "Success!" else "ERROR"
                         ),
@@ -2080,12 +2080,11 @@ class AppConfig(GlobalConfig):
                     continue  # 只统计在范围内的日期
 
                 if mode == "DAILY":
-                    date_name = f"{date.year}年 {date.month:02d}月 {date.day:02d}日"
+                    date_name = date.strftime("%Y-%m-%d")
                 elif mode == "WEEKLY":
-                    year, week, _ = date.isocalendar()
-                    date_name = f"{year}年 第{week}周"
+                    date_name = date.strftime("%G-W%V")
                 elif mode == "MONTHLY":
-                    date_name = f"{date.year}年 {date.month:02d}月"
+                    date_name = date.strftime("%Y-%m")
                 else:
                     raise ValueError("无效的合并模式")
 

--- a/frontend/src/utils/dateDisplay.ts
+++ b/frontend/src/utils/dateDisplay.ts
@@ -1,0 +1,81 @@
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+const ISO_MONTH_RE = /^\d{4}-\d{2}$/
+const ISO_WEEK_RE = /^(\d{4})-W(\d{2})$/
+const ISO_DATETIME_RE =
+  /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2})(?::(\d{2}))?(?:\.(\d+))?(?:Z|[+-]\d{2}:?\d{2})?$/
+const CN_DATETIME_RE =
+  /^(\d{4})年\s*(\d{1,2})月\s*(\d{1,2})日\s*(\d{1,2}):(\d{2})(?::(\d{2}))?$/
+
+const pad2 = (value: number) => String(value).padStart(2, '0')
+
+const toLocalDate = (
+  year: number,
+  month: number,
+  day: number,
+  hour = 0,
+  minute = 0,
+  second = 0,
+  millisecond = 0
+) => new Date(year, month - 1, day, hour, minute, second, millisecond)
+
+export const parseBackendDateTime = (value: string): Date | null => {
+  if (!value) return null
+
+  // 优先解析旧中文格式，避免依赖浏览器对本地化日期字符串的支持。
+  const cnMatch = value.trim().match(CN_DATETIME_RE)
+  if (cnMatch) {
+    const [, y, mo, d, h, mi, s = '0'] = cnMatch
+    return toLocalDate(Number(y), Number(mo), Number(d), Number(h), Number(mi), Number(s))
+  }
+
+  const normalized = value.includes(' ') ? value.replace(' ', 'T') : value
+  const parsed = new Date(normalized)
+  if (!Number.isNaN(parsed.getTime())) return parsed
+
+  const isoMatch = value.trim().match(ISO_DATETIME_RE)
+  if (isoMatch) {
+    const [, y, mo, d, h, mi, s = '0', ms = '0'] = isoMatch
+    return toLocalDate(
+      Number(y),
+      Number(mo),
+      Number(d),
+      Number(h),
+      Number(mi),
+      Number(s),
+      Number(ms.slice(0, 3).padEnd(3, '0'))
+    )
+  }
+
+  return null
+}
+
+export const formatBackendDateTime = (value: string): string => {
+  const date = parseBackendDateTime(value)
+  if (!date) return value
+
+  return `${date.getFullYear()}年${pad2(date.getMonth() + 1)}月${pad2(date.getDate())}日 ${pad2(
+    date.getHours()
+  )}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}`
+}
+
+export const formatHistoryGroupLabel = (value: string): string => {
+  if (!value) return value
+
+  if (ISO_DATE_RE.test(value)) {
+    const [year, month, day] = value.split('-')
+    return `${year}年${month}月${day}日`
+  }
+
+  if (ISO_MONTH_RE.test(value)) {
+    const [year, month] = value.split('-')
+    return `${year}年${month}月`
+  }
+
+  const weekMatch = value.match(ISO_WEEK_RE)
+  if (weekMatch) {
+    const [, year, week] = weekMatch
+    return `${year}年 第${week}周`
+  }
+
+  return value
+}

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -238,8 +238,8 @@ import { Service } from '@/api/services/Service'
 import NoticeModal from '@/components/NoticeModal.vue'
 import { useAudioPlayer } from '@/composables/useAudioPlayer'
 import { useAppInitialization } from '@/composables/useAppInitialization'
-import dayjs from 'dayjs'
 import { OpenAPI } from '@/api'
+import { formatBackendDateTime } from '@/utils/dateDisplay'
 const logger = window.electronAPI.getLogger('首页')
 
 interface ActivityInfo {
@@ -306,8 +306,10 @@ const currentActivity = computed(() => {
 })
 
 const formatProxyDisplay = (dateStr: string) => {
-  const ts = getProxyTimestamp(dateStr)
-  return dayjs(ts).format('YYYY-MM-DD HH:mm:ss') // 需要别的格式可改这里
+  if (dateStr === '暂无代理数据') {
+    return dateStr
+  }
+  return formatBackendDateTime(dateStr)
 }
 
 // 格式化时间显示 - 直接使用给定时间，不进行时区转换
@@ -348,24 +350,6 @@ const getActivityTimeStatus = (expireTime: string): 'normal' | 'warning' | 'ende
     return 'normal'
   } catch {
     return 'ended'
-  }
-}
-
-// 获取代理时间戳 - 解析后端返回的中文日期格式
-const getProxyTimestamp = (dateStr: string) => {
-  if (!dateStr) return Date.now()
-
-  // 处理后端返回的中文日期格式: "2025年11月05日 16:02:00"
-  try {
-    // 将中文日期格式转换为标准格式
-    const standardFormat = dateStr.replace(/年/g, '-').replace(/月/g, '-').replace(/日/g, '').trim()
-
-    const t = new Date(standardFormat).getTime()
-    return Number.isNaN(t) ? Date.now() : t
-  } catch {
-    // 兜底：尝试让浏览器自己解析
-    const t = new Date(dateStr).getTime()
-    return Number.isNaN(t) ? Date.now() : t
   }
 }
 

--- a/frontend/src/views/history/components/HistoryDateSidebar.vue
+++ b/frontend/src/views/history/components/HistoryDateSidebar.vue
@@ -14,7 +14,7 @@
         <a-collapse-panel v-for="dateGroup in historyData" :key="dateGroup.date" class="date-panel">
           <template #header>
             <div class="date-header">
-              <span class="date-text">{{ dateGroup.date }}</span>
+              <span class="date-text">{{ formatDateGroup(dateGroup.date) }}</span>
             </div>
           </template>
 
@@ -46,6 +46,7 @@
 import type { HistoryData } from '@/api'
 import { CalendarOutlined, RightOutlined, UserOutlined } from '@ant-design/icons-vue'
 import { ref, watch } from 'vue'
+import { formatHistoryGroupLabel } from '@/utils/dateDisplay'
 import type { HistoryDateGroup } from '../useHistoryLogic.ts'
 
 interface Props {
@@ -74,6 +75,8 @@ const handleCollapseChange = (keys: string | string[]) => {
   const newKeys = Array.isArray(keys) ? keys : keys ? [keys] : []
   emit('update:activeKeys', newKeys)
 }
+
+const formatDateGroup = (date: string) => formatHistoryGroupLabel(date)
 </script>
 
 <style scoped>

--- a/frontend/src/views/history/components/HistoryRecordList.vue
+++ b/frontend/src/views/history/components/HistoryRecordList.vue
@@ -31,7 +31,7 @@
           <div class="record-status-bar" :class="record.status === 'DONE' ? 'success' : 'error'" />
           <div class="record-content">
             <div class="record-main">
-              <span class="record-time">{{ record.date }}</span>
+              <span class="record-time">{{ formatRecordTime(record.date) }}</span>
               <a-tag :color="record.status === 'DONE' ? 'success' : 'error'" size="small" class="status-tag">
                 <CheckCircleOutlined v-if="record.status === 'DONE'" />
                 <CloseCircleOutlined v-else />
@@ -61,6 +61,7 @@ import {
   RightOutlined,
   UnorderedListOutlined,
 } from '@ant-design/icons-vue'
+import { formatBackendDateTime } from '@/utils/dateDisplay'
 
 interface RecordItem {
   date: string
@@ -79,6 +80,8 @@ defineProps<Props>()
 defineEmits<{
   (e: 'select', index: number, record: RecordItem): void
 }>()
+
+const formatRecordTime = (date: string) => formatBackendDateTime(date)
 </script>
 
 <style scoped>

--- a/frontend/src/views/history/index.vue
+++ b/frontend/src/views/history/index.vue
@@ -55,6 +55,7 @@ import HistoryDetailPanel from './components/HistoryDetailPanel.vue'
 import HistoryLogModal from './components/HistoryLogModal.vue'
 import HistorySearchPanel from './components/HistorySearchPanel.vue'
 import { useHistoryLogic } from './useHistoryLogic'
+import { formatBackendDateTime } from '@/utils/dateDisplay'
 
 const {
   // 状态
@@ -97,7 +98,7 @@ const currentErrorMessage = ref('')
 
 // 选择记录时打开弹窗
 const handleSelectRecord = async (index: number, record: any) => {
-  currentRecordDate.value = record.date
+  currentRecordDate.value = formatBackendDateTime(record.date)
   currentRecordStatus.value = record.status
   // 获取错误信息
   const errorInfo = selectedUserData.value?.error_info


### PR DESCRIPTION
根据[文档](https://docs.python.org/3.12/library/datetime.html#technical-detail)，

> For the same reason, handling of format strings containing Unicode code points that can’t be represented in the charset of the current locale is also platform-dependent. On some platforms such code points are preserved intact in the output, while on others strftime may raise [UnicodeError](https://docs.python.org/3.14/library/exceptions.html#UnicodeError) or return an empty string instead.

`strftime` 的处理非当前 locale 字符的行为与平台有关，在 Windows 上似乎是抛出 UnicodeEncodeError。

这里我直接给它改成 f-string 了。

附日志与 traceback：
```
2026-03-17 09:53:21.120 | ERROR    | 配置管理 | 非日期格式的目录: C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\history\2026-03-17
Traceback (most recent call last):

  File "C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\main.py", line 210, in <module>
    main()
    └ <function main at 0x000001B807068A40>

  File "C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\main.py", line 200, in main
    asyncio.run(run_server())
    │       │   └ <function main.<locals>.run_server at 0x000001B82063E520>
    │       └ <function run at 0x000001B8046ADE40>
    └ <module 'asyncio' from 'C:\\Users\\nucbox\\Desktop\\AUTO-MAS-Full-v5.0.4-x64\\environment\\python\\python312.zip\\asyncio\\__...

  File "asyncio\runners.py", line 194, in run

  File "asyncio\runners.py", line 118, in run

  File "asyncio\base_events.py", line 651, in run_until_complete

  File "asyncio\windows_events.py", line 321, in run_forever

  File "asyncio\base_events.py", line 618, in run_forever

  File "asyncio\base_events.py", line 1951, in _run_once

  File "asyncio\events.py", line 84, in _run

  File "C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\environment\python\Lib\site-packages\uvicorn\protocols\http\h11_impl.py", line 403, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
                   └ <uvicorn.middleware.proxy_headers.ProxyHeadersMiddleware object at 0x000001B807AFFAD0>
  File "C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\environment\python\Lib\site-packages\uvicorn\middleware\proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
                 │    │   │      │        └ <bound method RequestResponseCycle.send of <uvicorn.protocols.http.h11_impl.RequestResponseCycle object at 0x000001B82035F320>>
                 │    │   │      └ <bound method RequestResponseCycle.receive of <uvicorn.protocols.http.h11_impl.RequestResponseCycle object at 0x000001B82035F...
                 │    │   └ {'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('127.0.0.1', 36163), 'c...
                 │    └ <fastapi.applications.FastAPI object at 0x000001B81EBD00E0>
                 └ <uvicorn.middleware.proxy_headers.ProxyHeadersMiddleware object at 0x000001B807AFFAD0>
  File "C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\environment\python\Lib\site-packages\fastapi\applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
                           │      │        └ <bound method RequestResponseCycle.send of <uvicorn.protocols.http.h11_impl.RequestResponseCycle object at 0x000001B82035F320>>
                           │      └ <bound method RequestResponseCycle.receive of <uvicorn.protocols.http.h11_impl.RequestResponseCycle object at 0x000001B82035F...
                           └ {'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('127.0.0.1', 36163), 'c...
  File "C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\environment\python\Lib\site-packages\starlette\applications.py", line 113, in __call__
    await self.middleware_stack(scope, receive, send)
          │    │                │      │        └ <bound method RequestResponseCycle.send of <uvicorn.protocols.http.h11_impl.RequestResponseCycle object at 0x000001B82035F320>>
          │    │                │      └ <bound method RequestResponseCycle.receive of <uvicorn.protocols.http.h11_impl.RequestResponseCycle object at 0x000001B82035F...
          │    │                └ {'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('127.0.0.1', 36163), 'c...
          │    └ <starlette.middleware.errors.ServerErrorMiddleware object at 0x000001B82049FD70>
          └ <fastapi.applications.FastAPI object at 0x000001B81EBD00E0>
  File "C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\environment\python\Lib\site-packages\starlette\middleware\errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
          │    │   │      │        └ <function ServerErrorMiddleware.__call__.<locals>._send at 0x000001B8204884A0>
          │    │   │      └ <bound method RequestResponseCycle.receive of <uvicorn.protocols.http.h11_impl.RequestResponseCycle object at 0x000001B82035F...
          │    │   └ {'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('127.0.0.1', 36163), 'c...
          │    └ <starlette.middleware.cors.CORSMiddleware object at 0x000001B82049F500>
          └ <starlette.middleware.errors.ServerErrorMiddleware object at 0x000001B82049FD70>
  File "C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\environment\python\Lib\site-packages\starlette\middleware\cors.py", line 85, in __call__
    await self.app(scope, receive, send)
          │    │   │      │        └ <function ServerErrorMiddleware.__call__.<locals>._send at 0x000001B8204884A0>
          │    │   │      └ <bound method RequestResponseCycle.receive of <uvicorn.protocols.http.h11_impl.RequestResponseCycle object at 0x000001B82035F...
          │    │   └ {'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('127.0.0.1', 36163), 'c...
          │    └ <starlette.middleware.exceptions.ExceptionMiddleware object at 0x000001B82049F350>
          └ <starlette.middleware.cors.CORSMiddleware object at 0x000001B82049F500>
  File "C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\environment\python\Lib\site-packages\starlette\middleware\exceptions.py", line 63, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
          │                            │    │    │     │      │        └ <function ServerErrorMiddleware.__call__.<locals>._send at 0x000001B8204884A0>
          │                            │    │    │     │      └ <bound method RequestResponseCycle.receive of <uvicorn.protocols.http.h11_impl.RequestResponseCycle object at 0x000001B82035F...
          │                            │    │    │     └ {'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('127.0.0.1', 36163), 'c...
          │                            │    │    └ <starlette.requests.Request object at 0x000001B8203D3CB0>
          │                            │    └ <fastapi.routing.APIRouter object at 0x000001B82027DB20>
          │                            └ <starlette.middleware.exceptions.ExceptionMiddleware object at 0x000001B82049F350>
          └ <function wrap_app_handling_exceptions at 0x000001B8057C7560>
  File "C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\environment\python\Lib\site-packages\starlette\_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
          │   │      │        └ <function wrap_app_handling_exceptions.<locals>.wrapped_app.<locals>.sender at 0x000001B820488B80>
          │   │      └ <bound method RequestResponseCycle.receive of <uvicorn.protocols.http.h11_impl.RequestResponseCycle object at 0x000001B82035F...
          │   └ {'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('127.0.0.1', 36163), 'c...
          └ <fastapi.routing.APIRouter object at 0x000001B82027DB20>
  File "C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\environment\python\Lib\site-packages\starlette\routing.py", line 716, in __call__
    await self.middleware_stack(scope, receive, send)
          │    │                │      │        └ <function wrap_app_handling_exceptions.<locals>.wrapped_app.<locals>.sender at 0x000001B820488B80>
          │    │                │      └ <bound method RequestResponseCycle.receive of <uvicorn.protocols.http.h11_impl.RequestResponseCycle object at 0x000001B82035F...
          │    │                └ {'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('127.0.0.1', 36163), 'c...
          │    └ <bound method Router.app of <fastapi.routing.APIRouter object at 0x000001B82027DB20>>
          └ <fastapi.routing.APIRouter object at 0x000001B82027DB20>
  File "C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\environment\python\Lib\site-packages\starlette\routing.py", line 736, in app
    await route.handle(scope, receive, send)
          │     │      │      │        └ <function wrap_app_handling_exceptions.<locals>.wrapped_app.<locals>.sender at 0x000001B820488B80>
          │     │      │      └ <bound method RequestResponseCycle.receive of <uvicorn.protocols.http.h11_impl.RequestResponseCycle object at 0x000001B82035F...
          │     │      └ {'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('127.0.0.1', 36163), 'c...
          │     └ <function Route.handle at 0x000001B8057F4C20>
          └ APIRoute(path='/api/history/search', name='search_history', methods=['POST'])
  File "C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\environment\python\Lib\site-packages\starlette\routing.py", line 290, in handle
    await self.app(scope, receive, send)
          │    │   │      │        └ <function wrap_app_handling_exceptions.<locals>.wrapped_app.<locals>.sender at 0x000001B820488B80>
          │    │   │      └ <bound method RequestResponseCycle.receive of <uvicorn.protocols.http.h11_impl.RequestResponseCycle object at 0x000001B82035F...
          │    │   └ {'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('127.0.0.1', 36163), 'c...
          │    └ <function request_response.<locals>.app at 0x000001B8202F2D40>
          └ APIRoute(path='/api/history/search', name='search_history', methods=['POST'])
  File "C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\environment\python\Lib\site-packages\starlette\routing.py", line 78, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
          │                            │    │        │      │        └ <function wrap_app_handling_exceptions.<locals>.wrapped_app.<locals>.sender at 0x000001B820488B80>
          │                            │    │        │      └ <bound method RequestResponseCycle.receive of <uvicorn.protocols.http.h11_impl.RequestResponseCycle object at 0x000001B82035F...
          │                            │    │        └ {'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('127.0.0.1', 36163), 'c...
          │                            │    └ <starlette.requests.Request object at 0x000001B8203D3410>
          │                            └ <function request_response.<locals>.app.<locals>.app at 0x000001B820488220>
          └ <function wrap_app_handling_exceptions at 0x000001B8057C7560>
  File "C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\environment\python\Lib\site-packages\starlette\_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
          │   │      │        └ <function wrap_app_handling_exceptions.<locals>.wrapped_app.<locals>.sender at 0x000001B8204893A0>
          │   │      └ <bound method RequestResponseCycle.receive of <uvicorn.protocols.http.h11_impl.RequestResponseCycle object at 0x000001B82035F...
          │   └ {'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('127.0.0.1', 36163), 'c...
          └ <function request_response.<locals>.app.<locals>.app at 0x000001B820488220>
  File "C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\environment\python\Lib\site-packages\starlette\routing.py", line 75, in app
    response = await f(request)
                     │ └ <starlette.requests.Request object at 0x000001B8203D3410>
                     └ <function get_request_handler.<locals>.app at 0x000001B8202F2DE0>
  File "C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\environment\python\Lib\site-packages\fastapi\routing.py", line 302, in app
    raw_response = await run_endpoint_function(
                         └ <function run_endpoint_function at 0x000001B8057A1580>
  File "C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\environment\python\Lib\site-packages\fastapi\routing.py", line 213, in run_endpoint_function
    return await dependant.call(**values)
                 │         │      └ {'history': HistorySearchIn(mode='DAILY', start_date='2026-03-10', end_date='2026-03-17')}
                 │         └ <function search_history at 0x000001B8084B7F60>
                 └ Dependant(path_params=[], query_params=[], header_params=[], cookie_params=[], body_params=[ModelField(field_info=Body(Pydant...

  File "C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\app\api\history.py", line 44, in search_history
    data = await Config.search_history(
                 │      └ <function AppConfig.search_history at 0x000001B807B19DA0>
                 └ <app.core.config.AppConfig object at 0x000001B8078B9400>

> File "C:\Users\nucbox\Desktop\AUTO-MAS-Full-v5.0.4-x64\app\core\config.py", line 2066, in search_history
    date_name = date.strftime("%Y年 %m月 %d日")
                │    └ <method 'strftime' of 'datetime.date' objects>
                └ datetime.date(2026, 3, 17)

UnicodeEncodeError: 'locale' codec can't encode character '\u5e74' in position 2: encoding error
2026-03-17 09:53:21.131 | SUCCESS  | 配置管理 | 历史记录搜索完成, 共计 0 条记录
2026-03-17 09:53:21.131 | INFO     | 主程序 | 127.0.0.1:53442 - "POST /api/history/search HTTP/1.1" 200
```