### PR TITLE
feat(websocket): 一个websocket简易框架实现

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -33,7 +33,8 @@ from .tools import router as tools_router
 from .setting import router as setting_router
 from .update import router as update_router
 from .ocr import router as ocr_router
-from .ws_debug import router as ws_debug_router
+from .websocket import router as ws_router
+from .plugins import router as plugins_router
 
 __all__ = [
     "core_router",
@@ -48,5 +49,6 @@ __all__ = [
     "setting_router",
     "update_router",
     "ocr_router",
-    "ws_debug_router",
+    "ws_router",
+    "plugins_router",
 ]

--- a/app/api/core.py
+++ b/app/api/core.py
@@ -31,6 +31,7 @@ from app.services import System
 from app.models.schema import *
 from app.api.ws_command import ws_command
 from app.utils import get_logger
+from app.utils.websocket import ws_client_manager
 
 router = APIRouter(prefix="/api/core", tags=["核心信息"])
 logger = get_logger("DEV")
@@ -51,45 +52,27 @@ async def connect_websocket(websocket: WebSocket):
         return
 
     await websocket.accept()
-    Config.websocket = websocket
-    last_pong = time.monotonic()
-    last_ping = time.monotonic()
-    data = {}
-
-    asyncio.create_task(TaskManager.start_startup_queue())
-
-    while True:
-
-        try:
-
-            data = await asyncio.wait_for(websocket.receive_json(), timeout=15.0)
-            if data.get("type") == "Signal" and "Pong" in data.get("data", {}):
-                last_pong = time.monotonic()
-            elif data.get("type") == "Signal" and "Ping" in data.get("data", {}):
-                await websocket.send_json(
-                    WebSocketMessage(
-                        id="Main", type="Signal", data={"Pong": "无描述"}
-                    ).model_dump()
-                )
-            else:
-                await Broadcast.put(data)
-
-        except asyncio.TimeoutError:
-
-            if last_pong < last_ping:
-                await websocket.close(code=1000, reason="Ping超时")
-                break
-            await websocket.send_json(
-                WebSocketMessage(
-                    id="Main", type="Signal", data={"Ping": "无描述"}
-                ).model_dump()
-            )
-            last_ping = time.monotonic()
-
-        except WebSocketDisconnect:
-            break
-
     Config.websocket = None
+
+    async def on_message(data: dict):
+        await Broadcast.put(data)
+
+    async def on_disconnect():
+        Config.websocket = None
+
+    session = await ws_client_manager.openwsr(
+        name=ws_client_manager.MAIN_CLIENT_NAME,
+        websocket=websocket,
+        ping_interval=15.0,
+        ping_timeout=30.0,
+        on_message=on_message,
+        on_disconnect=on_disconnect,
+    )
+
+    Config.websocket = session
+    asyncio.create_task(TaskManager.start_startup_queue())
+    await session.wait_closed()
+
     if is_backend_dev_mode():
         logger.warning("后端开发模式下检测到 WS 断链，跳过 KillSelf 自动退出")
     else:

--- a/app/api/websocket.py
+++ b/app/api/websocket.py
@@ -28,7 +28,8 @@ WebSocket 客户端调试 API
 支持：创建客户端、连接、断开、发送消息、鉴权等
 """
 
-from typing import Optional
+import json
+from typing import Optional, Dict, Any, Callable
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from app.utils.websocket import ws_client_manager
@@ -51,10 +52,125 @@ from app.models.schema import (
     WSCommandsOut,
 )
 
-logger = get_logger("WS调试")
+logger = get_logger("WS端点")
 
-router = APIRouter(prefix="/api/ws_debug", tags=["WebSocket调试"])
+router = APIRouter(prefix="/api/ws", tags=["Websocket端点"])
+WSDEV_CHANNEL_NAME = "wsdev"
 
+
+async def _send_wsdev_snapshot(websocket: WebSocket):
+    """
+    发送 wsdev 初始化快照。
+
+    Args:
+        websocket: 当前调试前端的 WebSocket 连接。
+
+    Raises:
+        Exception: 发送初始化数据失败时抛出底层异常。
+    """
+    # 发送当前所有客户端状态
+    clients = ws_client_manager.list_clients()
+    await websocket.send_json({"type": "init", "clients": list(clients.values())})
+
+    # 发送历史消息
+    history = ws_client_manager.get_message_history()
+    for client_name, messages in history.items():
+        for msg in messages:
+            await websocket.send_json({"type": "message", "client": client_name, **msg})
+
+
+async def _invoke_declared_callback(callback: Optional[Callable], *args):
+    """
+    调用声明式回调并自动兼容同步/异步函数。
+
+    Args:
+        callback: 声明式回调函数。
+        *args: 传递给回调的参数。
+
+    Raises:
+        Exception: 回调执行过程中抛出的原始异常会向上抛出。
+    """
+    if callback is None:
+        return
+
+    result = callback(*args)
+    if hasattr(result, "__await__"):
+        await result
+
+
+def _build_channel_handlers(
+    channel_name: str,
+    websocket: WebSocket,
+    channel_config: Dict[str, Any],
+):
+    """
+    构建声明式通道的消息与生命周期回调。
+
+    Args:
+        channel_name: 通道名称。
+        websocket: 当前 WebSocket 连接。
+        channel_config: 通道声明配置。
+
+    Returns:
+        tuple: `(on_message, on_connect, on_disconnect)` 三个回调。
+    """
+    declared_on_message = channel_config.get("on_message")
+    declared_on_connect = channel_config.get("on_connect")
+    declared_on_disconnect = channel_config.get("on_disconnect")
+
+    if channel_name == WSDEV_CHANNEL_NAME:
+
+        async def on_message(data: Dict[str, Any]):
+            action = data.get("action") if isinstance(data, dict) else None
+            if action == "ping":
+                await websocket.send_text("pong")
+            elif action == "request_snapshot":
+                await _send_wsdev_snapshot(websocket)
+            await _invoke_declared_callback(declared_on_message, data)
+
+        async def on_connect():
+            ws_client_manager.add_debug_connection(websocket)
+            logger.info(f"调试前端已连接 (/api/ws/{channel_name}): {websocket.client}")
+            await _send_wsdev_snapshot(websocket)
+            await _invoke_declared_callback(declared_on_connect)
+
+        async def on_disconnect():
+            ws_client_manager.remove_debug_connection(websocket)
+            logger.info(f"调试前端已断开 (/api/ws/{channel_name}): {websocket.client}")
+            await _invoke_declared_callback(declared_on_disconnect)
+
+        return on_message, on_connect, on_disconnect
+
+    async def on_message(data: Dict[str, Any]):
+        await _invoke_declared_callback(declared_on_message, data)
+
+    async def on_connect():
+        logger.info(f"声明通道已连接 (/api/ws/{channel_name}): {websocket.client}")
+        await _invoke_declared_callback(declared_on_connect)
+
+    async def on_disconnect():
+        logger.info(f"声明通道已断开 (/api/ws/{channel_name}): {websocket.client}")
+        await _invoke_declared_callback(declared_on_disconnect)
+
+    return on_message, on_connect, on_disconnect
+
+
+def _register_builtin_reverse_channels():
+    """
+    注册内置声明式反向通道。
+
+    Raises:
+        ValueError: 当内置通道名称非法或与保留名称冲突时抛出。
+    """
+    ws_client_manager.register_reverse_channel(
+        name=WSDEV_CHANNEL_NAME,
+        ping_interval=15.0,
+        ping_timeout=30.0,
+        overwrite=True,
+    )
+
+
+_register_builtin_reverse_channels()
 
 # ============== API 路由 ==============
 
@@ -454,44 +570,39 @@ async def get_commands() -> WSCommandsOut:
     )
 
 
-@router.websocket("/live")
-async def websocket_live(websocket: WebSocket):
+@router.websocket("/{channel_name}")
+async def websocket_dynamic_channel(websocket: WebSocket, channel_name: str):
     """
-    实时消息推送 WebSocket 端点
+    声明式动态 WebSocket 端点。
 
-    前端连接此端点后，可实时接收所有客户端的消息和事件
+    路由会根据 `channel_name` 查找管理器中的声明配置，
+    并统一通过 `openwsr` 接管当前连接。
+
+    Raises:
+        Exception: 会话创建或运行失败时抛出底层异常。
     """
+    channel_config = ws_client_manager.get_reverse_channel_config(channel_name)
+    if channel_config is None:
+        logger.warning(f"未声明的反向通道连接被拒绝: /api/ws/{channel_name}")
+        await websocket.close(code=1008, reason=f"未声明通道: {channel_name}")
+        return
+
     await websocket.accept()
-    ws_client_manager.add_debug_connection(websocket)
 
-    logger.info(f"调试前端已连接: {websocket.client}")
+    on_message, on_connect, on_disconnect = _build_channel_handlers(
+        channel_name=channel_name,
+        websocket=websocket,
+        channel_config=channel_config,
+    )
 
-    try:
-        # 发送当前所有客户端状态
-        clients = ws_client_manager.list_clients()
-        await websocket.send_json({"type": "init", "clients": list(clients.values())})
-
-        # 发送历史消息
-        history = ws_client_manager.get_message_history()
-        for client_name, messages in history.items():
-            for msg in messages:
-                await websocket.send_json(
-                    {"type": "message", "client": client_name, **msg}
-                )
-
-        # 保持连接，接收心跳
-        while True:
-            try:
-                data = await websocket.receive_text()
-                # 处理心跳或其他命令
-                if data == "ping":
-                    await websocket.send_text("pong")
-            except WebSocketDisconnect:
-                break
-            except Exception as e:
-                logger.error(f"WebSocket 错误: {e}")
-                break
-
-    finally:
-        ws_client_manager.remove_debug_connection(websocket)
-        logger.info(f"调试前端已断开: {websocket.client}")
+    session = await ws_client_manager.openwsr(
+        name=channel_name,
+        websocket=websocket,
+        ping_interval=float(channel_config.get("ping_interval", 15.0)),
+        ping_timeout=float(channel_config.get("ping_timeout", 30.0)),
+        auth_token=channel_config.get("auth_token"),
+        on_message=on_message,
+        on_connect=on_connect,
+        on_disconnect=on_disconnect,
+    )
+    await session.wait_closed()

--- a/app/utils/websocket.py
+++ b/app/utils/websocket.py
@@ -24,6 +24,7 @@
 import time
 import asyncio
 import json
+import re
 from typing import Optional, Callable, Any, Dict, List
 
 from websockets.asyncio.client import connect, ClientConnection
@@ -32,6 +33,246 @@ from websockets.exceptions import ConnectionClosed
 from app.utils.logger import get_logger
 
 # ============== WebSocket 客户端实例 ==============
+
+
+class ReverseWebSocketSession:
+    """反向 WebSocket 会话，封装 FastAPI/Starlette 服务端侧连接。"""
+
+    def __init__(
+        self,
+        websocket: Any,
+        name: str,
+        ping_interval: float = 15.0,
+        ping_timeout: float = 30.0,
+        on_message: Optional[Callable[[Dict[str, Any]], Any]] = None,
+        on_connect: Optional[Callable[[], Any]] = None,
+        on_disconnect: Optional[Callable[[], Any]] = None,
+        auth_token: Optional[str] = None,
+    ):
+        """初始化反向 WebSocket 会话。"""
+        self.websocket = websocket
+        self.name = name
+        self.logger = get_logger(f"WS反向会话:{self.name}")
+
+        self.ping_interval = ping_interval
+        self.ping_timeout = ping_timeout
+        self.reconnect_interval = 0.0
+        self.max_reconnect_attempts = 0
+        self.on_message = on_message
+        self.on_connect = on_connect
+        self.on_disconnect = on_disconnect
+        self._auth_token = auth_token
+
+        self._running = False
+        self._last_ping = 0.0
+        self._last_pong = 0.0
+        self._tasks: list[asyncio.Task] = []
+        self._closed_event = asyncio.Event()
+        self._disconnect_notified = False
+
+    @property
+    def direction(self) -> str:
+        """返回会话方向标识。"""
+        return "inbound"
+
+    @property
+    def url(self) -> str:
+        """返回反向连接的伪 URL，便于调试界面展示。"""
+        scope = getattr(self.websocket, "scope", {}) or {}
+        path = scope.get("path") or ""
+        client = getattr(self.websocket, "client", None)
+        if client:
+            return f"reverse://{client.host}:{client.port}{path}"
+        return f"reverse://{path.lstrip('/')}"
+
+    @property
+    def is_system(self) -> bool:
+        """反向会话默认视为系统会话。"""
+        return True
+
+    @property
+    def is_connected(self) -> bool:
+        """检查反向会话是否仍处于连接状态。"""
+        client_state = getattr(self.websocket, "client_state", None)
+        application_state = getattr(self.websocket, "application_state", None)
+        client_state_name = getattr(client_state, "name", str(client_state))
+        application_state_name = getattr(application_state, "name", str(application_state))
+        return client_state_name == "CONNECTED" and application_state_name != "DISCONNECTED"
+
+    async def start(self) -> bool:
+        """启动反向会话的收发和心跳任务。"""
+        if self._running:
+            return True
+
+        self._running = True
+        self._last_ping = time.monotonic()
+        self._last_pong = time.monotonic()
+
+        if self.on_connect:
+            result = self.on_connect()
+            if asyncio.iscoroutine(result):
+                await result
+
+        if self._auth_token:
+            await self.send_auth(self._auth_token)
+
+        receive_task = asyncio.create_task(self._receive_loop())
+        heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+        self._tasks = [receive_task, heartbeat_task]
+        return True
+
+    async def wait_closed(self):
+        """等待反向会话关闭。"""
+        await self._closed_event.wait()
+
+    async def run(self):
+        """启动并阻塞运行反向会话。"""
+        await self.start()
+        await self.wait_closed()
+
+    async def send(self, message: Dict[str, Any]) -> bool:
+        """发送 JSON 消息到反向连接的客户端。"""
+        if not self.is_connected:
+            self.logger.warning("WebSocket 未连接，无法发送消息")
+            return False
+
+        try:
+            await self.websocket.send_json(message)
+            return True
+        except Exception as e:
+            self.logger.error(f"发送消息失败: {type(e).__name__}: {e}")
+            return False
+
+    async def send_json(self, data: Dict[str, Any]) -> bool:
+        """兼容 FastAPI WebSocket 的 send_json 接口。"""
+        return await self.send(data)
+
+    async def send_auth(
+        self,
+        token: str,
+        auth_type: str = "auth",
+        extra_data: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """发送认证消息。"""
+        self._auth_token = token
+        auth_message = {
+            "id": "Client",
+            "type": auth_type,
+            "data": {"token": token, **(extra_data or {})},
+        }
+        return await self.send(auth_message)
+
+    async def close(self, code: int = 1000, reason: str = "正常关闭"):
+        """关闭反向 WebSocket 会话。"""
+        self._running = False
+        for task in self._tasks:
+            if not task.done():
+                task.cancel()
+        self._tasks.clear()
+
+        try:
+            if self.is_connected:
+                await self.websocket.close(code=code, reason=reason)
+        except Exception as e:
+            self.logger.warning(f"关闭反向会话时发生异常: {type(e).__name__}: {e}")
+        finally:
+            await self._notify_disconnect()
+            self._closed_event.set()
+
+    async def disconnect(self):
+        """兼容统一的断开接口。"""
+        await self.close()
+
+    async def _notify_disconnect(self):
+        """触发断开回调，确保只执行一次。"""
+        if self._disconnect_notified:
+            return
+        self._disconnect_notified = True
+        if self.on_disconnect:
+            result = self.on_disconnect()
+            if asyncio.iscoroutine(result):
+                await result
+
+    async def _send_ping(self):
+        """发送应用层 Ping。"""
+        message = {"id": "Client", "type": "Signal", "data": {"Ping": "heartbeat"}}
+        if await self.send(message):
+            self._last_ping = time.monotonic()
+            self.logger.debug("已发送 Ping")
+
+    async def _send_pong(self):
+        """发送应用层 Pong。"""
+        message = {"id": "Client", "type": "Signal", "data": {"Pong": "heartbeat"}}
+        await self.send(message)
+        self.logger.debug("已发送 Pong")
+
+    async def _handle_message(self, raw_message: Any):
+        """处理接收到的消息。"""
+        try:
+            if isinstance(raw_message, str):
+                data = json.loads(raw_message)
+            else:
+                data = raw_message
+
+            if data.get("type") == "Signal":
+                signal_data = data.get("data", {})
+                if "Pong" in signal_data:
+                    self._last_pong = time.monotonic()
+                    self.logger.debug("收到 Pong")
+                    return
+                if "Ping" in signal_data:
+                    self.logger.debug("收到 Ping")
+                    await self._send_pong()
+                    return
+
+            if self.on_message:
+                result = self.on_message(data)
+                if asyncio.iscoroutine(result):
+                    await result
+        except json.JSONDecodeError as e:
+            self.logger.warning(f"消息解析失败: {e}")
+        except Exception as e:
+            self.logger.error(f"处理消息时发生异常: {type(e).__name__}: {e}")
+
+    async def _receive_loop(self):
+        """消息接收循环。"""
+        while self._running and self.is_connected:
+            try:
+                message = await asyncio.wait_for(
+                    self.websocket.receive_json(), timeout=self.ping_interval
+                )
+                await self._handle_message(message)
+            except asyncio.TimeoutError:
+                continue
+            except Exception as e:
+                self.logger.warning(f"接收消息时连接关闭或异常: {type(e).__name__}: {e}")
+                break
+
+        self._running = False
+        await self._notify_disconnect()
+        self._closed_event.set()
+
+    async def _heartbeat_loop(self):
+        """心跳维护循环。"""
+        while self._running and self.is_connected:
+            try:
+                current_time = time.monotonic()
+                if self._last_pong < self._last_ping:
+                    time_since_ping = current_time - self._last_ping
+                    if time_since_ping > self.ping_timeout:
+                        self.logger.warning(f"Pong 超时 ({time_since_ping:.1f}s)，断开连接")
+                        break
+
+                if current_time - self._last_ping >= self.ping_interval:
+                    await self._send_ping()
+
+                await asyncio.sleep(1.0)
+            except Exception as e:
+                self.logger.error(f"心跳循环异常: {type(e).__name__}: {e}")
+                break
+
+        self._running = False
+        await self.close()
 
 
 class WebSocketClient:
@@ -153,6 +394,10 @@ class WebSocketClient:
             if asyncio.iscoroutine(result):
                 await result
 
+    async def close(self, code: int = 1000, reason: str = "正常关闭"):
+        """兼容统一的关闭接口。"""
+        await self.disconnect()
+
     async def send(self, message: Dict[str, Any]) -> bool:
         """
         发送 JSON 消息
@@ -173,6 +418,28 @@ class WebSocketClient:
         except Exception as e:
             self.logger.error(f"发送消息失败: {type(e).__name__}: {e}")
             return False
+
+    async def send_json(self, data: Dict[str, Any]) -> bool:
+        """兼容 FastAPI WebSocket 的 send_json 接口。"""
+        return await self.send(data)
+
+    async def send_auth(
+        self,
+        token: str,
+        auth_type: str = "auth",
+        extra_data: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """发送认证消息。"""
+        self._auth_token = token
+        auth_message = {
+            "id": "Client",
+            "type": auth_type,
+            "data": {"token": token, **(extra_data or {})},
+        }
+        success = await self.send(auth_message)
+        if success:
+            self.logger.info("已发送认证消息")
+        return success
 
     async def _send_ping(self):
         """发送应用层 Ping"""
@@ -489,24 +756,195 @@ class WSClientManager:
     """WebSocket 客户端管理器，用于管理多个 WebSocket 客户端实例"""
 
     # 系统客户端名称常量
+    MAIN_CLIENT_NAME = "Main"
     KOISHI_CLIENT_NAME = "Koishi"
+    _CHANNEL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 
     def __init__(self):
         self._clients: Dict[str, WebSocketClient] = {}
+        self._reverse_sessions: Dict[str, Any] = {}
         self._system_clients: set[str] = set()  # 系统客户端名称集合
         self._tasks: Dict[str, asyncio.Task] = {}
         self._message_history: Dict[str, List[Dict[str, Any]]] = {}
+        self._reverse_channel_registry: Dict[str, Dict[str, Any]] = {}
         self._max_history_per_client = 200
         self._debug_connections: List[Any] = []  # WebSocket 连接列表
         self._logger = get_logger("WS管理器")
+        self._reserved_reverse_channels: set[str] = {
+            "client",
+            "message",
+            "history",
+            "commands",
+        }
+        self._system_clients.add(self.MAIN_CLIENT_NAME)
+        self._system_clients.add(self.KOISHI_CLIENT_NAME)
+
+    def register_reverse_channel(
+        self,
+        name: str,
+        ping_interval: float = 15.0,
+        ping_timeout: float = 30.0,
+        auth_token: Optional[str] = None,
+        on_message: Optional[Callable[[Dict[str, Any]], Any]] = None,
+        on_connect: Optional[Callable[[], Any]] = None,
+        on_disconnect: Optional[Callable[[], Any]] = None,
+        overwrite: bool = True,
+    ):
+        """
+        注册反向 WebSocket 通道声明。
+
+        Args:
+            name: 通道名称，将映射为 `/api/ws/{name}`。
+            ping_interval: 应用层心跳发送间隔（秒）。
+            ping_timeout: Pong 超时时间（秒）。
+            auth_token: 连接建立后自动发送的认证 Token。
+            on_message: 收到业务消息时回调。
+            on_connect: 连接建立时回调。
+            on_disconnect: 连接断开时回调。
+            overwrite: 若同名声明已存在，是否覆盖。
+
+        Raises:
+            ValueError: 当 `name` 为空、格式非法、命中保留名称或且已存在但不允许覆盖时抛出。
+        """
+        normalized_name = (name or "").strip()
+        if not normalized_name:
+            raise ValueError("通道名称不能为空")
+
+        if not self._CHANNEL_NAME_PATTERN.fullmatch(normalized_name):
+            raise ValueError("通道名称仅支持字母、数字、下划线和中划线")
+
+        if normalized_name in self._reserved_reverse_channels:
+            raise ValueError(f"通道名称 [{normalized_name}] 为保留路径，不能注册")
+
+        if not overwrite and normalized_name in self._reverse_channel_registry:
+            raise ValueError(f"通道声明 [{normalized_name}] 已存在")
+
+        self._reverse_channel_registry[normalized_name] = {
+            "name": normalized_name,
+            "ping_interval": ping_interval,
+            "ping_timeout": ping_timeout,
+            "auth_token": auth_token,
+            "on_message": on_message,
+            "on_connect": on_connect,
+            "on_disconnect": on_disconnect,
+            "updated_at": time.time(),
+        }
+
+    def unregister_reverse_channel(self, name: str) -> bool:
+        """
+        注销反向 WebSocket 通道声明。
+
+        Args:
+            name: 目标通道名称。
+
+        Returns:
+            bool: 当声明存在并成功移除时返回 `True`，否则返回 `False`。
+
+        Raises:
+            ValueError: 当 `name` 为空时抛出。
+        """
+        normalized_name = (name or "").strip()
+        if not normalized_name:
+            raise ValueError("通道名称不能为空")
+
+        if normalized_name in self._reverse_channel_registry:
+            del self._reverse_channel_registry[normalized_name]
+            return True
+        return False
+
+    def is_reverse_channel_registered(self, name: str) -> bool:
+        """
+        检查反向通道是否已声明。
+
+        Args:
+            name: 目标通道名称。
+
+        Returns:
+            bool: 已声明返回 `True`，否则返回 `False`。
+        """
+        return (name or "").strip() in self._reverse_channel_registry
+
+    def get_reverse_channel_config(self, name: str) -> Optional[Dict[str, Any]]:
+        """
+        获取单个反向通道声明配置。
+
+        Args:
+            name: 目标通道名称。
+
+        Returns:
+            Optional[Dict[str, Any]]: 若存在返回配置浅拷贝，否则返回 `None`。
+        """
+        config = self._reverse_channel_registry.get((name or "").strip())
+        if config is None:
+            return None
+        return config.copy()
+
+    def list_reverse_channels(self) -> Dict[str, Dict[str, Any]]:
+        """
+        列出全部反向通道声明。
+
+        Returns:
+            Dict[str, Dict[str, Any]]: 键为通道名，值为配置浅拷贝。
+        """
+        return {
+            channel_name: channel_config.copy()
+            for channel_name, channel_config in self._reverse_channel_registry.items()
+        }
 
     def get_client(self, name: str) -> Optional[WebSocketClient]:
         """获取客户端实例"""
-        return self._clients.get(name)
+        client = self._clients.get(name)
+        if client is not None:
+            return client
+        return self._reverse_sessions.get(name)
+
+    def get_session(self, name: str) -> Optional[Any]:
+        """获取任意方向的会话实例。"""
+        return self._clients.get(name) or self._reverse_sessions.get(name)
+
+    async def wait_for_reverse_session(self, name: str, timeout: Optional[float] = None):
+        """
+        等待指定反向会话实例出现并返回。
+
+        该方法适用于“通道已声明，但连接尚未建立”的场景，
+        会持续轮询 `_reverse_sessions` 直到会话可用或超时。
+
+        Args:
+            name: 反向会话名称。
+            timeout: 最大等待时长（秒）。传 `None` 表示无限等待。
+
+        Returns:
+            Any: 等待到的反向会话实例。
+
+        Raises:
+            ValueError: 当 `name` 为空，或 `timeout` 小于等于 0 时抛出。
+            TimeoutError: 当在 `timeout` 时间内仍未等到会话实例时抛出。
+        """
+        normalized_name = (name or "").strip()
+        if not normalized_name:
+            raise ValueError("会话名称不能为空")
+
+        if timeout is not None and timeout <= 0:
+            raise ValueError("timeout 必须大于 0")
+
+        loop = asyncio.get_running_loop()
+        deadline = None if timeout is None else (loop.time() + timeout)
+
+        while True:
+            session = self._reverse_sessions.get(normalized_name)
+            if session is not None:
+                return session
+
+            if deadline is not None and loop.time() >= deadline:
+                raise TimeoutError(
+                    f"等待反向会话 [{normalized_name}] 超时（{timeout}秒）"
+                )
+
+            await asyncio.sleep(0.5)
 
     def has_client(self, name: str) -> bool:
         """检查客户端是否存在"""
-        return name in self._clients
+        return name in self._clients or name in self._reverse_sessions
 
     def is_system_client(self, name: str) -> bool:
         """检查是否为系统客户端"""
@@ -515,12 +953,13 @@ class WSClientManager:
     def list_clients(self) -> Dict[str, Dict[str, Any]]:
         """列出所有客户端及其状态"""
         result = {}
-        for name, client in self._clients.items():
+        for name, client in {**self._clients, **self._reverse_sessions}.items():
             result[name] = {
                 "name": name,
                 "url": client.url,
                 "is_connected": client.is_connected,
                 "is_system": name in self._system_clients,
+                "direction": getattr(client, "direction", "outbound"),
                 "ping_interval": client.ping_interval,
                 "ping_timeout": client.ping_timeout,
                 "reconnect_interval": client.reconnect_interval,
@@ -540,8 +979,11 @@ class WSClientManager:
     ) -> WebSocketClient:
         """创建新的 WebSocket 客户端"""
 
+        if name in self._reverse_sessions and name in self._system_clients:
+            raise ValueError(f"系统会话 [{name}] 已被占用，不能创建同名正向客户端")
+
         # 如果已存在同名客户端，先移除
-        if name in self._clients:
+        if name in self._clients or name in self._reverse_sessions:
             await self.remove_client(name)
 
         # 创建消息回调
@@ -585,14 +1027,131 @@ class WSClientManager:
         self._clients[name] = client
         self._message_history[name] = []
 
+        await self._broadcast_event(
+            {
+                "event": "created",
+                "client": name,
+                "url": url,
+                "timestamp": time.time(),
+            }
+        )
+
         self._logger.info(f"已创建 WebSocket 客户端: {name} -> {url}")
         return client
+
+    async def openws(
+        self,
+        name: str,
+        url: str,
+        ping_interval: float = 15.0,
+        ping_timeout: float = 30.0,
+        reconnect_interval: float = 5.0,
+        max_reconnect_attempts: int = -1,
+    ) -> WebSocketClient:
+        """正式的正向 WebSocket 打开接口。"""
+        client = await self.create_client(
+            name=name,
+            url=url,
+            ping_interval=ping_interval,
+            ping_timeout=ping_timeout,
+            reconnect_interval=reconnect_interval,
+            max_reconnect_attempts=max_reconnect_attempts,
+        )
+        await self.connect_client(name)
+        return client
+
+    async def openwsr(
+        self,
+        name: str,
+        websocket: Any,
+        ping_interval: float = 15.0,
+        ping_timeout: float = 30.0,
+        auth_token: Optional[str] = None,
+        on_message: Optional[Callable[[Dict[str, Any]], Any]] = None,
+        on_connect: Optional[Callable[[], Any]] = None,
+        on_disconnect: Optional[Callable[[], Any]] = None,
+    ) -> ReverseWebSocketSession:
+        """正式的反向 WebSocket 打开接口。"""
+        if name in self._clients and name in self._system_clients:
+            raise ValueError(f"系统会话 [{name}] 已被正向客户端占用，不能创建同名反向会话")
+
+        if name in self._clients:
+            await self.remove_client(name)
+
+        if name in self._reverse_sessions:
+            await self.disconnect_client(name)
+
+        async def wrapped_on_message(data: Dict[str, Any]):
+            await self._record_message(name, "received", data)
+            if on_message:
+                result = on_message(data)
+                if asyncio.iscoroutine(result):
+                    await result
+
+        async def wrapped_on_connect():
+            self._logger.info(f"反向会话 [{name}] 已连接")
+            await self._broadcast_event(
+                {
+                    "event": "connected",
+                    "client": name,
+                    "url": f"reverse://{name}",
+                    "direction": "inbound",
+                    "timestamp": time.time(),
+                }
+            )
+            if on_connect:
+                result = on_connect()
+                if asyncio.iscoroutine(result):
+                    await result
+
+        async def wrapped_on_disconnect():
+            self._logger.info(f"反向会话 [{name}] 已断开")
+            await self._broadcast_event(
+                {
+                    "event": "disconnected",
+                    "client": name,
+                    "direction": "inbound",
+                    "timestamp": time.time(),
+                }
+            )
+            if on_disconnect:
+                result = on_disconnect()
+                if asyncio.iscoroutine(result):
+                    await result
+
+        session = ReverseWebSocketSession(
+            websocket=websocket,
+            name=name,
+            ping_interval=ping_interval,
+            ping_timeout=ping_timeout,
+            on_message=wrapped_on_message,
+            on_connect=wrapped_on_connect,
+            on_disconnect=wrapped_on_disconnect,
+            auth_token=auth_token,
+        )
+        self._reverse_sessions[name] = session
+        self._message_history[name] = []
+
+        await self._broadcast_event(
+            {
+                "event": "created",
+                "client": name,
+                "url": session.url,
+                "direction": session.direction,
+                "timestamp": time.time(),
+            }
+        )
+
+        self._logger.info(f"已创建反向 WebSocket 会话: {name} -> {session.url}")
+        await session.start()
+        return session
 
     async def connect_client(self, name: str) -> bool:
         """连接客户端（非阻塞方式启动）"""
         client = self._clients.get(name)
         if not client:
-            return False
+            session = self._reverse_sessions.get(name)
+            return session.is_connected if session else False
 
         if client.is_connected:
             return True
@@ -632,10 +1191,14 @@ class WSClientManager:
     async def disconnect_client(self, name: str) -> bool:
         """断开客户端连接"""
         client = self._clients.get(name)
-        if not client:
+        session = self._reverse_sessions.get(name)
+        if not client and not session:
             return False
 
-        await client.disconnect()
+        if client:
+            await client.disconnect()
+        if session:
+            await session.disconnect()
 
         # 取消任务
         if name in self._tasks:
@@ -648,11 +1211,14 @@ class WSClientManager:
                     pass
             del self._tasks[name]
 
+        if name in self._reverse_sessions and name not in self._system_clients:
+            del self._reverse_sessions[name]
+
         return True
 
     async def remove_client(self, name: str) -> bool:
         """删除客户端（系统客户端不可删除）"""
-        if name not in self._clients:
+        if name not in self._clients and name not in self._reverse_sessions:
             return False
 
         # 系统客户端不可删除
@@ -664,18 +1230,29 @@ class WSClientManager:
         await self.disconnect_client(name)
 
         # 删除客户端
-        del self._clients[name]
+        if name in self._clients:
+            del self._clients[name]
+        if name in self._reverse_sessions:
+            del self._reverse_sessions[name]
 
         # 清理消息历史
         if name in self._message_history:
             del self._message_history[name]
+
+        await self._broadcast_event(
+            {
+                "event": "removed",
+                "client": name,
+                "timestamp": time.time(),
+            }
+        )
 
         self._logger.info(f"已删除 WebSocket 客户端: {name}")
         return True
 
     async def send_message(self, name: str, message: Dict[str, Any]) -> bool:
         """发送消息"""
-        client = self._clients.get(name)
+        client = self.get_session(name)
         if not client or not client.is_connected:
             return False
 
@@ -692,6 +1269,18 @@ class WSClientManager:
         extra_data: Optional[Dict[str, Any]] = None,
     ) -> bool:
         """发送认证消息"""
+        client = self.get_session(name)
+        if not client or not client.is_connected:
+            return False
+
+        if hasattr(client, "send_auth"):
+            try:
+                return await client.send_auth(
+                    token=token, auth_type=auth_type, extra_data=extra_data
+                )
+            except TypeError:
+                pass
+
         auth_message = {
             "id": "Client",
             "type": auth_type,
@@ -721,8 +1310,12 @@ class WSClientManager:
         await self._broadcast(message)
 
     async def _broadcast_event(self, event: Dict[str, Any]):
-        """广播事件给调试前端"""
-        message = {"type": "event", **event}
+        """广播事件给调试前端，并附带最新客户端列表快照。"""
+        message = {
+            "type": "event",
+            "clients": list(self.list_clients().values()),
+            **event,
+        }
         await self._broadcast(message)
 
     async def _broadcast(self, data: Dict[str, Any]):
@@ -774,11 +1367,21 @@ class WSClientManager:
                 self._message_history[key] = []
 
     def add_debug_connection(self, ws: Any):
-        """添加调试前端连接"""
+        """
+        添加调试前端连接。
+
+        Args:
+            ws: 调试前端连接对象。
+        """
         self._debug_connections.append(ws)
 
     def remove_debug_connection(self, ws: Any):
-        """移除调试前端连接"""
+        """
+        移除调试前端连接。
+
+        Args:
+            ws: 调试前端连接对象。
+        """
         if ws in self._debug_connections:
             self._debug_connections.remove(ws)
 

--- a/frontend/src/components/devtools/QuickNavPage.vue
+++ b/frontend/src/components/devtools/QuickNavPage.vue
@@ -162,7 +162,7 @@ const toggleConsole = () => {
     logger.info(`localStorage项目数: ${Object.keys(localStorage).length}`)
     logger.info(`sessionStorage项目数: ${Object.keys(sessionStorage).length}`)
     if ((window as any).wsDebug) {
-      logger.info(`WebSocket调试: ${(window as any).wsDebug}`)
+      logger.info(`Websocket端点: ${(window as any).wsDebug}`)
     }
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error)

--- a/frontend/src/views/WSdev.vue
+++ b/frontend/src/views/WSdev.vue
@@ -333,7 +333,7 @@ import {
   LockOutlined,
 } from '@ant-design/icons-vue'
 import { message } from 'ant-design-vue'
-import { WebSocketService } from '@/api'
+import { OpenAPI, WebSocketService } from '@/api'
 
 // ============== 类型定义 ==============
 
@@ -401,6 +401,9 @@ const createForm = ref({
 
 // 实时 WebSocket 连接
 let liveWs: WebSocket | null = null
+let reconnectAttempts = 0
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+let manualClose = false
 
 // ============== 计算属性 ==============
 
@@ -462,14 +465,12 @@ function formatTime(timestamp: number): string {
 
 // 刷新客户端列表
 async function refreshClientList() {
-  try {
-    const response = await WebSocketService.listClientsApiWsDebugClientListGet()
-    if (response.code === 200 && response.data) {
-      clientList.value = response.data.clients || []
-    }
-  } catch (error: any) {
-    console.error('刷新客户端列表失败:', error)
+  if (liveWs && liveWs.readyState === WebSocket.OPEN) {
+    liveWs.send(JSON.stringify({ action: 'request_snapshot' }))
+    return
   }
+
+  message.warning('实时通道未连接，暂时无法刷新快照')
 }
 
 // 选择客户端
@@ -540,14 +541,13 @@ async function createClient() {
       reconnect_interval: createForm.value.reconnectInterval,
       max_reconnect_attempts: createForm.value.maxReconnectAttempts,
     }
-    logApiRequest('/api/ws_debug/client/create', 'POST', requestBody)
+    logApiRequest('/api/ws/client/create', 'POST', requestBody)
     const response = await WebSocketService.createClientApiWsDebugClientCreatePost(requestBody)
-    logApiResponse('/api/ws_debug/client/create', response)
+    logApiResponse('/api/ws/client/create', response)
 
     if (response.code === 200) {
       message.success(`客户端 [${createForm.value.name}] 创建成功`)
       createModalVisible.value = false
-      await refreshClientList()
       selectedClient.value = createForm.value.name
     } else {
       message.error(response.message || '创建失败')
@@ -564,13 +564,12 @@ async function connectClient(name: string) {
   connectingClients.value[name] = true
   try {
     const requestBody = { name }
-    logApiRequest('/api/ws_debug/client/connect', 'POST', requestBody)
+    logApiRequest('/api/ws/client/connect', 'POST', requestBody)
     const response = await WebSocketService.connectClientApiWsDebugClientConnectPost(requestBody)
-    logApiResponse('/api/ws_debug/client/connect', response)
+    logApiResponse('/api/ws/client/connect', response)
 
     if (response.code === 200) {
       message.success(`客户端 [${name}] 连接成功`)
-      await refreshClientList()
     } else {
       message.error(response.message || '连接失败')
     }
@@ -585,13 +584,12 @@ async function connectClient(name: string) {
 async function disconnectClient(name: string) {
   try {
     const requestBody = { name }
-    logApiRequest('/api/ws_debug/client/disconnect', 'POST', requestBody)
+    logApiRequest('/api/ws/client/disconnect', 'POST', requestBody)
     const response = await WebSocketService.disconnectClientApiWsDebugClientDisconnectPost(requestBody)
-    logApiResponse('/api/ws_debug/client/disconnect', response)
+    logApiResponse('/api/ws/client/disconnect', response)
 
     if (response.code === 200) {
       message.success(`客户端 [${name}] 已断开`)
-      await refreshClientList()
     } else {
       message.error(response.message || '断开失败')
     }
@@ -604,16 +602,15 @@ async function disconnectClient(name: string) {
 async function removeClient(name: string) {
   try {
     const requestBody = { name }
-    logApiRequest('/api/ws_debug/client/remove', 'POST', requestBody)
+    logApiRequest('/api/ws/client/remove', 'POST', requestBody)
     const response = await WebSocketService.removeClientApiWsDebugClientRemovePost(requestBody)
-    logApiResponse('/api/ws_debug/client/remove', response)
+    logApiResponse('/api/ws/client/remove', response)
 
     if (response.code === 200) {
       message.success(`客户端 [${name}] 已删除`)
       if (selectedClient.value === name) {
         selectedClient.value = null
       }
-      await refreshClientList()
     } else {
       message.error(response.message || '删除失败')
     }
@@ -648,9 +645,9 @@ async function sendMessage() {
         msg_type: formattedMessage.value.type,
         data,
       }
-      logApiRequest('/api/ws_debug/message/send_json', 'POST', jsonRequestBody)
+      logApiRequest('/api/ws/message/send_json', 'POST', jsonRequestBody)
       response = await WebSocketService.sendJsonMessageApiWsDebugMessageSendJsonPost(jsonRequestBody)
-      logApiResponse('/api/ws_debug/message/send_json', response)
+      logApiResponse('/api/ws/message/send_json', response)
     } else if (sendMode.value === 'raw') {
       let messageObj: any
       try {
@@ -664,9 +661,9 @@ async function sendMessage() {
         name: selectedClient.value,
         message: messageObj,
       }
-      logApiRequest('/api/ws_debug/message/send', 'POST', rawRequestBody)
+      logApiRequest('/api/ws/message/send', 'POST', rawRequestBody)
       response = await WebSocketService.sendMessageApiWsDebugMessageSendPost(rawRequestBody)
-      logApiResponse('/api/ws_debug/message/send', response)
+      logApiResponse('/api/ws/message/send', response)
     } else if (sendMode.value === 'auth') {
       if (!authMessage.value.token) {
         message.error('请输入认证 Token')
@@ -689,9 +686,9 @@ async function sendMessage() {
         auth_type: authMessage.value.type,
         extra_data: extraData,
       }
-      logApiRequest('/api/ws_debug/message/auth', 'POST', authRequestBody)
+      logApiRequest('/api/ws/message/auth', 'POST', authRequestBody)
       response = await WebSocketService.sendAuthApiWsDebugMessageAuthPost(authRequestBody)
-      logApiResponse('/api/ws_debug/message/auth', response)
+      logApiResponse('/api/ws/message/auth', response)
     }
 
     if (response?.code === 200) {
@@ -734,13 +731,18 @@ function addMessage(record: MessageRecord) {
 
 // 建立实时 WebSocket 连接
 function connectLiveWs() {
-  const wsUrl = `ws://${window.location.host}/api/ws_debug/live`
+  const wsUrl = buildLiveWsUrl()
 
   try {
     liveWs = new WebSocket(wsUrl)
 
     liveWs.onopen = () => {
       console.log('实时消息连接已建立')
+      reconnectAttempts = 0
+
+      if (liveWs && liveWs.readyState === WebSocket.OPEN) {
+        liveWs.send(JSON.stringify({ action: 'request_snapshot' }))
+      }
     }
 
     liveWs.onmessage = (event) => {
@@ -750,6 +752,7 @@ function connectLiveWs() {
         if (data.type === 'init') {
           // 初始化客户端列表
           clientList.value = data.clients || []
+          messages.value = []
         } else if (data.type === 'message') {
           // 添加消息记录
           addMessage({
@@ -759,9 +762,9 @@ function connectLiveWs() {
             client: data.client,
           })
         } else if (data.type === 'event') {
-          // 处理事件
-          if (data.event === 'connected' || data.event === 'disconnected') {
-            refreshClientList()
+          // 后端事件统一携带最新客户端快照
+          if (Array.isArray(data.clients)) {
+            clientList.value = data.clients
           }
         }
       } catch (error) {
@@ -776,49 +779,69 @@ function connectLiveWs() {
     liveWs.onclose = () => {
       console.log('实时消息连接已关闭')
       liveWs = null
-      // 5秒后重连
-      setTimeout(connectLiveWs, 5000)
+
+      if (manualClose) {
+        return
+      }
+
+      reconnectAttempts += 1
+      const delay = getReconnectDelay(reconnectAttempts)
+      reconnectTimer = setTimeout(connectLiveWs, delay)
     }
   } catch (error) {
     console.error('创建实时消息连接失败:', error)
+
+    if (!manualClose) {
+      reconnectAttempts += 1
+      const delay = getReconnectDelay(reconnectAttempts)
+      reconnectTimer = setTimeout(connectLiveWs, delay)
+    }
   }
+}
+
+function getReconnectDelay(attempt: number): number {
+  const baseMs = 1000
+  const maxMs = 30000
+  const delay = baseMs * 2 ** Math.max(attempt - 1, 0)
+  return Math.min(delay, maxMs)
+}
+
+// 根据 OpenAPI.BASE 构建 WS 地址，确保和 HTTP API 指向同一后端
+function buildLiveWsUrl(): string {
+  const base = (OpenAPI.BASE || '').trim()
+  if (base) {
+    if (base.startsWith('https://')) {
+      return `${base.replace('https://', 'wss://')}/api/ws/wsdev`
+    }
+    if (base.startsWith('http://')) {
+      return `${base.replace('http://', 'ws://')}/api/ws/wsdev`
+    }
+    if (base.startsWith('wss://') || base.startsWith('ws://')) {
+      return `${base}/api/ws/wsdev`
+    }
+  }
+
+  const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws'
+  return `${protocol}://${window.location.host}/api/ws/wsdev`
 }
 
 // 断开实时 WebSocket
 function disconnectLiveWs() {
+  manualClose = true
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer)
+    reconnectTimer = null
+  }
+
   if (liveWs) {
     liveWs.close()
     liveWs = null
   }
 }
 
-// 加载历史消息
-async function loadHistory() {
-  try {
-    const response = await WebSocketService.getHistoryApiWsDebugHistoryGet()
-    if (response.code === 200 && response.data?.history) {
-      messages.value = []
-      const history = response.data.history
-      for (const clientName of Object.keys(history)) {
-        for (const msg of history[clientName]) {
-          messages.value.push({
-            ...msg,
-            client: clientName,
-          })
-        }
-      }
-      // 按时间排序
-      messages.value.sort((a, b) => a.timestamp - b.timestamp)
-    }
-  } catch (error: any) {
-    console.error('加载历史消息失败:', error)
-  }
-}
-
 // 页面加载时
 onMounted(async () => {
-  await refreshClientList()
-  await loadHistory()
+  manualClose = false
   connectLiveWs()
 })
 
@@ -934,6 +957,33 @@ onUnmounted(() => {
   max-height: 400px;
   overflow-y: auto;
   padding: 8px;
+}
+
+.demo-trend {
+  margin-top: 16px;
+  max-height: 180px;
+  overflow-y: auto;
+  border: 1px solid var(--ant-color-border-secondary);
+  border-radius: 8px;
+  padding: 8px;
+}
+
+.demo-point {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 4px;
+  border-bottom: 1px dashed var(--ant-color-border-secondary);
+}
+
+.demo-point:last-child {
+  border-bottom: none;
+}
+
+.demo-point-time {
+  font-family: 'Consolas', 'Monaco', monospace;
+  color: var(--ant-color-text-secondary);
+  font-size: 12px;
 }
 
 .message-item {

--- a/main.py
+++ b/main.py
@@ -127,7 +127,8 @@ def main():
             setting_router,
             update_router,
             ocr_router,
-            ws_debug_router,
+            ws_router,
+            plugins_router,
         )
 
         app = FastAPI(
@@ -158,6 +159,7 @@ def main():
         app.include_router(update_router)
         app.include_router(ocr_router)
         app.include_router(ws_debug_router)
+        app.include_router(plugins_router)
 
         app.mount(
             "/api/res/materials",

--- a/res/docs/WebSocket管理器快速上手.md
+++ b/res/docs/WebSocket管理器快速上手.md
@@ -1,0 +1,161 @@
+# WebSocket 管理器快速上手
+
+这份文档面向二次开发者，目标是用最少代码通过 `ws_client_manager` 创建并管理：
+
+- 正向连接（后端主动连外部 WS 服务）
+- 反向连接（外部客户端连入后端 WS 路由）
+
+管理器入口位于：`app.utils.websocket.ws_client_manager`
+
+---
+
+## 1. 正向连接：openws
+
+适用场景：你知道目标服务器地址，需要后端主动发起连接。
+
+```python
+from app.utils.websocket import ws_client_manager
+
+async def open_outbound_ws():
+    client = await ws_client_manager.openws(
+        name="MyOutbound",                 # 客户端唯一名称
+        url="ws://127.0.0.1:5140/ws",     # 目标 WS 地址
+        ping_interval=15.0,
+        ping_timeout=30.0,
+        reconnect_interval=5.0,
+        max_reconnect_attempts=-1,          # -1 表示无限重连
+    )
+
+    # 可选：发送认证
+    await ws_client_manager.send_auth(
+        name="MyOutbound",
+        token="your-token",
+        auth_type="auth",
+    )
+
+    # 可选：发送业务消息
+    await ws_client_manager.send_message(
+        "MyOutbound",
+        {"id": "Client", "type": "command", "data": {"hello": "world"}},
+    )
+
+    return client
+```
+
+---
+
+## 2. 反向连接：openwsr
+
+### 声明式动态反向通道（推荐）
+
+现在后端提供统一动态入口：`/api/ws/{channel_name}`。
+
+你只需要先声明通道，客户端连接到对应路径后，路由会自动调用 `openwsr` 接管：
+
+```python
+from app.utils.websocket import ws_client_manager
+
+# 启动阶段执行一次
+ws_client_manager.register_reverse_channel(
+    name="123123",
+    ping_interval=15.0,
+    ping_timeout=30.0,
+    auth_token="optional-token",
+)
+```
+
+然后让外部客户端连接：
+
+- `ws://<host>:<port>/api/ws/123123`
+
+注意：
+
+- 只有已声明通道会被放行；未声明会被拒绝。
+- `wsdev` 也已改为同样的声明式写法，入口为 `/api/ws/wsdev`。
+
+如果你需要在业务代码里拿到该通道对应的会话实例，可直接等待：
+
+```python
+session = await ws_client_manager.wait_for_reverse_session("123123", timeout=10)
+
+# session 可直接发送消息
+await session.send_json({"id": "Client", "type": "command", "data": {"ok": True}})
+```
+
+---
+
+## 3. 常用管理操作
+
+```python
+# 是否存在
+ws_client_manager.has_client("MyOutbound")
+
+# 读取统一会话对象（正向/反向都可）
+session = ws_client_manager.get_session("MyOutbound")
+
+# 列出所有连接状态
+clients = ws_client_manager.list_clients()
+
+# 断开连接
+await ws_client_manager.disconnect_client("MyOutbound")
+
+# 删除客户端（系统客户端不可删除）
+await ws_client_manager.remove_client("MyOutbound")
+```
+
+---
+
+## 3.1 WS 管理器方法总览
+
+以下为 `WSClientManager` 当前公共方法，按功能分组：
+
+- 反向通道声明：
+- `register_reverse_channel(name, ping_interval=15.0, ping_timeout=30.0, auth_token=None, on_message=None, on_connect=None, on_disconnect=None, overwrite=True)`
+- `unregister_reverse_channel(name)`
+- `is_reverse_channel_registered(name)`
+- `get_reverse_channel_config(name)`
+- `list_reverse_channels()`
+- 会话等待与查询：
+- `wait_for_reverse_session(name, timeout=None)`
+- `get_client(name)`
+- `get_session(name)`
+- `has_client(name)`
+- `is_system_client(name)`
+- `list_clients()`
+- 正向/反向连接控制：
+- `create_client(name, url, ping_interval=15.0, ping_timeout=30.0, reconnect_interval=5.0, max_reconnect_attempts=-1)`
+- `openws(name, url, ping_interval=15.0, ping_timeout=30.0, reconnect_interval=5.0, max_reconnect_attempts=-1)`
+- `openwsr(name, websocket, ping_interval=15.0, ping_timeout=30.0, auth_token=None, on_message=None, on_connect=None, on_disconnect=None)`
+- `connect_client(name)`
+- `disconnect_client(name)`
+- `remove_client(name)`
+- 消息相关：
+- `send_message(name, message)`
+- `send_auth(name, token, auth_type="auth", extra_data=None)`
+- `get_message_history(name=None)`
+- `clear_message_history(name=None)`
+- 调试连接维护：
+- `add_debug_connection(ws)`
+- `remove_debug_connection(ws)`
+- 其他工具：
+- `http_to_ws_url(http_url)`
+- `init_system_client_koishi()`
+- `update_system_client_koishi()`
+
+---
+
+## 4. 最佳实践
+
+- `name` 保持全局唯一，建议使用业务前缀（如 `Order-WS`、`Notify-WS`）。
+- 尽量通过 `ws_client_manager.send_message/send_auth` 统一发送，便于历史记录与调试页联动。
+- 反向路由中优先使用 `session.wait_closed()`，避免函数提前返回导致生命周期不一致。
+- 系统保留名称（如 `Main`、`Koishi`）不要用于普通业务连接。
+
+---
+
+## 5. 与现有代码对照
+
+你可以直接参考这两个实现：
+
+- 主反向连接入口：`app/api/core.py` 中 `/api/core/ws`
+- 管理器实现：`app/utils/websocket.py` 中 `WSClientManager.openws/openwsr`


### PR DESCRIPTION
详细使用教程于markdown WebSocket 管理器快速上手中已大致说明

添加了一个ws管理器，用于统一管理正向和反向的ws链接
添加了一个注册器，默认监听/api/ws/{name}，任何地方可以注册name，当访问对应地址后，通过api/webscoket.py 导航到对应的会话中，这样可以动态的使用这个/api/ws/{name}字段而不需要有事没事去改api
ws管理器可以主动发起ws链接（正向），也可以注册一个反向ws链接等待任何ws链接到端口，一般来讲，我们后端应该全部使用反向ws，让前端去连
send等普通方法见文档