### PR TITLE
fix: rename confg -> config in remove_privacy_info and fix f-string

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -761,29 +761,29 @@ class AppConfig(GlobalConfig):
                 logger.error(f"无法上传配置到 AUTO-MAS 服务器: {e}")
                 raise ConnectionError(f"无法上传配置到 AUTO-MAS 服务器: {e}")
 
-    async def remove_privacy_info(self, confg: dict, name: str) -> dict:
+    async def remove_privacy_info(self, config: dict, name: str) -> dict:
         """移除配置中可能存在的隐私信息"""
 
-        confg["Info"]["Name"] = name
+        config["Info"]["Name"] = name
         for path in ["ScriptPath", "ConfigPath", "LogPath", "TrackProcessExe"]:
-            if Path(confg["Script"][path]).is_relative_to(
-                Path(confg["Info"]["RootPath"])
+            if Path(config["Script"][path]).is_relative_to(
+                Path(config["Info"]["RootPath"])
             ):
-                confg["Script"][path] = str(
+                config["Script"][path] = str(
                     Path(r"C:/脚本根目录")
-                    / Path(confg["Script"][path]).relative_to(
-                        Path(confg["Info"]["RootPath"])
+                    / Path(config["Script"][path]).relative_to(
+                        Path(config["Info"]["RootPath"])
                     )
                 )
-            if sys.platform == "win32" and Path(confg["Script"][path]).is_relative_to(
+            if sys.platform == "win32" and Path(config["Script"][path]).is_relative_to(
                 Path(os.environ["APPDATA"])
             ):
-                confg["Script"][
+                config["Script"][
                     path
-                ] = f"%APPDATA%/{Path(confg["Script"][path]).relative_to(Path(os.environ["APPDATA"]))}"
-        confg["Info"]["RootPath"] = str(Path(r"C:/脚本根目录"))
+                ] = f"%APPDATA%/{Path(config['Script'][path]).relative_to(Path(os.environ['APPDATA']))}"
+        config["Info"]["RootPath"] = str(Path(r"C:/脚本根目录"))
 
-        return confg
+        return config
 
     async def get_user(
         self, script_id: str, user_id: Optional[str]


### PR DESCRIPTION
### Motivation

- Correct an obvious spelling mistake in the backend config sanitizer to improve readability and prevent future bugs.
- Ensure the privacy-cleanup code is syntactically correct and robust when constructing `%APPDATA%` paths on Windows.

### Description

- Renamed the `remove_privacy_info` parameter and all internal references from `confg` to `config` in `app/core/config.py`.
- Updated the code that rewrites relative script/config/log paths to use the corrected `config` variable consistently.
- Fixed the nested-quote usage in the `%APPDATA%` f-string by switching inner quotes to single quotes so the expression is syntactically valid.
- Preserved original behavior of mapping paths to `C:/脚本根目录` and formatting `%APPDATA%` placeholders.

### Testing

- Ran `python -m py_compile app/core/config.py`, which initially exposed a syntax error from the f-string and then passed after the fix.
- The final `python -m py_compile app/core/config.py` check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d77105b4e4832f8c3cb3617b366afc)