### PR TITLE
feat(M9A): 虚拟用户方案实现自动更新

### DIFF
--- a/app/models/config.py
+++ b/app/models/config.py
@@ -1478,6 +1478,10 @@ class M9AConfig(ConfigBase):
         self.Run_RunTimeLimit = ConfigItem(
             "Run", "RunTimeLimit", 10, RangeValidator(1, 9999)
         )
+        ## 是否在队列结束后自动更新
+        self.Run_IfAutoUpdateAfterQueue = ConfigItem(
+            "Run", "IfAutoUpdateAfterQueue", False, BoolValidator()
+        )
 
         self.UserData = MultipleConfig([M9AUserConfig])
 

--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -892,6 +892,7 @@ class M9AConfig_Run(BaseModel):
     ProxyTimesLimit: Optional[int] = Field(default=None, description="代理次数限制")
     RunTimesLimit: Optional[int] = Field(default=None, description="运行次数限制")
     RunTimeLimit: Optional[int] = Field(default=None, description="运行时间限制（分钟）")
+    IfAutoUpdateAfterQueue: Optional[bool] = Field(default=None, description="是否在队列结束后自动更新M9A")
 
 
 class M9AConfig(BaseModel):

--- a/app/task/M9A/AutoProxy.py
+++ b/app/task/M9A/AutoProxy.py
@@ -426,18 +426,6 @@ class AutoProxyTask(TaskExecuteBase):
                 logger.info("虚拟用户: M9A 准备重启应用更新")
                 self.script_info._m9a_restart_triggered = True
 
-            if getattr(self.script_info, '_m9a_restart_triggered', False):
-                version_match = re.search(r'资源版本：v([\d.]+)', log)
-                if version_match:
-                    new_version = version_match.group(1)
-                    old_version = getattr(self.script_info, '_m9a_current_version', '')
-                    if new_version != old_version:
-                        logger.info(f"虚拟用户: 更新成功！v{old_version} → v{new_version}")
-                        self.script_info._m9a_update_success = True
-                        self.cur_user_log.status = "Success!"
-                        self.wait_event.set()
-                        return
-
             if "[ERR]" in log and not getattr(self.script_info, '_m9a_restart_triggered', False):
                 err_content = log.split("[ERR]", 1)[1].strip() if "[ERR]" in log else ""
                 if err_content:

--- a/app/task/M9A/AutoProxy.py
+++ b/app/task/M9A/AutoProxy.py
@@ -79,8 +79,13 @@ class AutoProxyTask(TaskExecuteBase):
         self.m9a_task_loader = M9ATaskLoader(self.m9a_root_path)
         self.template_path = self.m9a_root_path / "config/instances/default.json"
 
+        self.is_first_user_for_version_check = False
+        self.is_virtual_update_user = False
 
     async def check(self) -> str:
+
+        if self.is_virtual_update_user:
+            return "Pass"
 
         if self.script_config.get(
             "Run", "ProxyTimesLimit"
@@ -110,10 +115,11 @@ class AutoProxyTask(TaskExecuteBase):
         self.task_dict = {}
 
         # 初始化每日代理状态
-        self.curdate = datetime.now(tz=UTC4).strftime("%Y-%m-%d")
-        if self.cur_user_config.get("Data", "LastProxyDate") != self.curdate:
-            await self.cur_user_config.set("Data", "LastProxyDate", self.curdate)
-            await self.cur_user_config.set("Data", "ProxyTimes", 0)
+        if not self.is_virtual_update_user:
+            self.curdate = datetime.now(tz=UTC4).strftime("%Y-%m-%d")
+            if self.cur_user_config.get("Data", "LastProxyDate") != self.curdate:
+                await self.cur_user_config.set("Data", "LastProxyDate", self.curdate)
+                await self.cur_user_config.set("Data", "ProxyTimes", 0)
 
         self.check_result = await self.check()
         if self.check_result != "Pass":
@@ -132,9 +138,10 @@ class AutoProxyTask(TaskExecuteBase):
         logger.info(f"开始代理用户: {self.cur_user_uid}")
         self.cur_user_item.status = "运行"
         self.run_complete = False
-        for i in range(self.script_config.get("Run", "RunTimesLimit")):
+        retry_limit = 1 if self.is_virtual_update_user else self.script_config.get("Run", "RunTimesLimit")
+        for i in range(retry_limit):
             logger.info(
-                f"用户 {self.cur_user_item.name} 自动代理模式 - 尝试次数: {i + 1}/{self.script_config.get('Run', 'RunTimesLimit')}"
+                f"用户 {self.cur_user_item.name} 自动代理模式 - 尝试次数: {i + 1}/{retry_limit}"
             )
             self.log_start_time = datetime.now()
             self.cur_user_item.log_record[self.log_start_time] = (
@@ -142,10 +149,13 @@ class AutoProxyTask(TaskExecuteBase):
             ) = LogRecord()
 
             try:
-                self.script_info.log = "正在启动模拟器"
-                emulator_info = await self.emulator_manager.open(
-                    self.script_config.get("Emulator", "Index"),
-                )
+                if self.is_virtual_update_user:
+                    emulator_info = None
+                else:
+                    self.script_info.log = "正在启动模拟器"
+                    emulator_info = await self.emulator_manager.open(
+                        self.script_config.get("Emulator", "Index"),
+                    )
             except Exception as e:
                 logger.exception(f"用户: {self.cur_user_uid} - 模拟器启动失败: {e}")
                 await Config.send_websocket_message(
@@ -173,7 +183,7 @@ class AutoProxyTask(TaskExecuteBase):
                 )
                 continue
 
-            if Config.get("Function", "IfSilence"):
+            if Config.get("Function", "IfSilence") and not self.is_virtual_update_user:
                 try:
                     await self.emulator_manager.setVisible(
                         self.script_config.get("Emulator", "Index"), False
@@ -194,7 +204,7 @@ class AutoProxyTask(TaskExecuteBase):
                     logger.error(f"任务队列 JSON 解析失败: {e}")
                     queue = []
 
-            if not queue:
+            if not queue and not self.is_virtual_update_user:
                 logger.warning(f"用户 {self.cur_user_uid} 未配置任务队列或队列为空")
                 self.cur_user_item.status = "异常"
                 return
@@ -240,12 +250,13 @@ class AutoProxyTask(TaskExecuteBase):
                 )
 
                 await self.m9a_process_manager.kill()
-                try:
-                    await self.emulator_manager.close(
-                        self.script_config.get("Emulator", "Index")
-                    )
-                except Exception as e:
-                    logger.exception(f"关闭模拟器失败: {e}")
+                if not self.is_virtual_update_user:
+                    try:
+                        await self.emulator_manager.close(
+                            self.script_config.get("Emulator", "Index")
+                        )
+                    except Exception as e:
+                        logger.exception(f"关闭模拟器失败: {e}")
                 await System.kill_process(self.m9a_exe_path)
 
                 await Notify.push_plyer(
@@ -261,24 +272,26 @@ class AutoProxyTask(TaskExecuteBase):
         """向 M9A 目录写入运行配置文件，并保存 debug 备份"""
         logger.info("开始配置 M9A 运行参数")
 
-        # 确保M9A进程已关闭
-        await self.m9a_process_manager.kill()
-        await System.kill_process(self.m9a_exe_path)
+        if not self.is_virtual_update_user:
+            await self.m9a_process_manager.kill()
+            await System.kill_process(self.m9a_exe_path)
 
-        # 使用 config_builder 构建完整配置
         try:
-            emulator_id = self.script_config.get("Emulator", "Id")
-            emulator_index = self.script_config.get("Emulator", "Index")
-            
-            config = await self.build_config(
-                queue=queue,
-                task_loader=self.m9a_task_loader,
-                emulator_info=emulator_info,
-                emulator_id=emulator_id,
-                script_config=self.script_config,
-                emulator_index=emulator_index,
-                emulator_manager=self.emulator_manager
-            )
+            if self.is_virtual_update_user:
+                config = await self._build_virtual_config()
+            else:
+                emulator_id = self.script_config.get("Emulator", "Id")
+                emulator_index = self.script_config.get("Emulator", "Index")
+
+                config = await self.build_config(
+                    queue=queue,
+                    task_loader=self.m9a_task_loader,
+                    emulator_info=emulator_info,
+                    emulator_id=emulator_id,
+                    script_config=self.script_config,
+                    emulator_index=emulator_index,
+                    emulator_manager=self.emulator_manager
+                )
         except Exception as e:
             logger.error(f"构建 M9A 配置失败: {e}")
             raise
@@ -333,20 +346,34 @@ class AutoProxyTask(TaskExecuteBase):
 
 
     async def check_log(self, log_content: list[str], latest_time: datetime) -> None:
-        """M9A 日志回调：分析实时日志，判断任务执行状态
-
-        策略说明：
-        - log_content 由 LogMonitor 根据 log_start_time 过滤，仅包含本次启动后的日志
-        - 不使用日志关键字做错误检测（M9A 在游戏加载时会输出大量 [ERR] 日志）
-        - 仅依赖进程退出状态和超时来判断异常
-        """
 
         log = "".join(log_content)
         self.cur_user_log.content = log_content
         self.script_info.log = log
 
+        if self.is_first_user_for_version_check:
+            version_keywords = [
+                "检测到资源有新版本",
+                "检测到新版本",
+                "Found new version",
+                "New version detected",
+            ]
+            if any(kw in log for kw in version_keywords):
+                if not getattr(self.script_info, '_m9a_has_new_version', False):
+                    self.script_info._m9a_has_new_version = True
+                    logger.info("在首个用户日志中检测到 M9A 新版本提示！")
+
+            version_match = re.search(r'当前资源版本：v([\d.]+)', log)
+            if version_match and not getattr(self.script_info, '_m9a_current_version', None):
+                self.script_info._m9a_current_version = version_match.group(1)
+
+            version_match = re.search(r'最新资源版本：v([\d.]+)', log)
+            if version_match:
+                self.script_info._m9a_latest_version = version_match.group(1)
+
         if "任务已全部完成！" in log or "All tasks completed" in log:
-            self.cur_user_log.status = "Success!"
+            if not self.is_virtual_update_user:
+                self.cur_user_log.status = "Success!"
         elif "已放弃本次任务" in log:
             self.cur_user_log.status = "M9A 已放弃本次任务"
         elif not await self.m9a_process_manager.is_running():
@@ -361,6 +388,101 @@ class AutoProxyTask(TaskExecuteBase):
         else:
             self.cur_user_log.status = "M9A 正常运行中"
 
+        if self.is_virtual_update_user:
+
+            if "获取资源包下载信息失败" in log:
+                reason_match = re.search(r'原因=(.+?)(?:\n|$)', log)
+                reason = reason_match.group(1).strip() if reason_match else "未知原因"
+                logger.warning(f"虚拟用户: M9A 资源更新失败 - {reason}")
+                self.cur_user_log.status = f"M9A 更新失败: {reason}"
+                if not hasattr(self.script_info, '_m9a_err_log'):
+                    self.script_info._m9a_err_log = []
+                self.script_info._m9a_err_log.append("获取资源包下载信息失败")
+                self.wait_event.set()
+                return
+
+            if "文件操作失败" in log and "远程主机强迫关闭了一个现有的连接" in log:
+                logger.warning("虚拟用户: M9A 更新下载失败 - 网络连接中断")
+                self.cur_user_log.status = "M9A 更新失败: 网络连接中断"
+                if not hasattr(self.script_info, '_m9a_err_log'):
+                    self.script_info._m9a_err_log = []
+                self.script_info._m9a_err_log.append("网络连接中断")
+                self.wait_event.set()
+                return
+
+            if "HTTP 请求失败" in log:
+                reason_match = re.search(r'原因=(.+?)(?:\n|$)', log)
+                reason = reason_match.group(1).strip() if reason_match else "HTTP 请求失败"
+                reason = re.sub(r'[（(][^）)]*[）)]$', '', reason).strip().rstrip('.')
+                logger.warning(f"虚拟用户: M9A HTTP 请求失败 - {reason}")
+                self.cur_user_log.status = f"M9A 更新失败: {reason}"
+                if not hasattr(self.script_info, '_m9a_err_log'):
+                    self.script_info._m9a_err_log = []
+                self.script_info._m9a_err_log.append("HTTP 请求失败")
+                self.wait_event.set()
+                return
+
+            if "准备重新启动应用" in log or "Preparing to restart" in log:
+                logger.info("虚拟用户: M9A 准备重启应用更新")
+                self.script_info._m9a_restart_triggered = True
+
+            if getattr(self.script_info, '_m9a_restart_triggered', False):
+                version_match = re.search(r'资源版本：v([\d.]+)', log)
+                if version_match:
+                    new_version = version_match.group(1)
+                    old_version = getattr(self.script_info, '_m9a_current_version', '')
+                    if new_version != old_version:
+                        logger.info(f"虚拟用户: 更新成功！v{old_version} → v{new_version}")
+                        self.script_info._m9a_update_success = True
+                        self.cur_user_log.status = "Success!"
+                        self.wait_event.set()
+                        return
+
+            if "[ERR]" in log and not getattr(self.script_info, '_m9a_restart_triggered', False):
+                err_content = log.split("[ERR]", 1)[1].strip() if "[ERR]" in log else ""
+                if err_content:
+                    err_content = re.sub(r'\[src=[^\]]+\]', '', err_content)
+                    err_content = re.sub(r'\[cfg=[^\]]+\]', '', err_content)
+                    err_content = re.sub(r'\[inst=[^\]]+\]', '', err_content)
+                    err_content = re.sub(r'\[op=[^\]]+\]', '', err_content)
+                    err_content = ' '.join(err_content.split())
+                    err_content = err_content.strip().rstrip('.')
+                    if err_content:
+                        logger.warning(f"虚拟用户: M9A 运行错误 - {err_content}")
+                        if not hasattr(self.script_info, '_m9a_err_log'):
+                            self.script_info._m9a_err_log = []
+                        short_err = err_content.split(' at ')[0].strip()
+                        if len(short_err) > 80:
+                            short_err = short_err[:77] + '...'
+                        self.script_info._m9a_err_log.append(short_err)
+
+            elapsed = (datetime.now() - self.log_start_time).total_seconds()
+            if elapsed > 600:
+                self.script_info._m9a_timeout = True
+                err_log = getattr(self.script_info, '_m9a_err_log', [])
+                err_suffix = f"（{err_log[-1]}）" if err_log else ""
+                logger.warning(f"虚拟用户: 更新超时（10分钟）{err_suffix}")
+                self.cur_user_log.status = f"M9A 更新超时"
+                self.wait_event.set()
+                return
+
+            if not await self.m9a_process_manager.is_running():
+                if getattr(self.script_info, '_m9a_restart_triggered', False):
+                    logger.info("虚拟用户: M9A 更新成功（进程已正常重启退出）")
+                    self.script_info._m9a_update_success = True
+                    self.cur_user_log.status = "Success!"
+                    self.wait_event.set()
+                    return
+                else:
+                    err_log = getattr(self.script_info, '_m9a_err_log', [])
+                    err_suffix = f"（{err_log[-1]}）" if err_log else ""
+                    logger.warning(f"虚拟用户: M9A 进程异常退出（未触发重启信号）{err_suffix}")
+                    self.cur_user_log.status = f"M9A 进程异常结束{err_suffix}"
+                    self.wait_event.set()
+                    return
+
+            return
+
         logger.debug(f"M9A 日志分析结果：{self.cur_user_log.status}")
         if self.cur_user_log.status != "M9A 正常运行中":
             logger.info(f"M9A 任务结果：{self.cur_user_log.status}")
@@ -369,7 +491,6 @@ class AutoProxyTask(TaskExecuteBase):
     async def final_task(self):
         """任务收尾：停止监控、结束进程、关闭模拟器、保存记录并推送通知"""
 
-        # 1) 停止日志监控（如果已启动）
         try:
             if hasattr(self, "m9a_log_monitor") and self.m9a_log_monitor is not None:
                 await self.m9a_log_monitor.stop()
@@ -377,6 +498,25 @@ class AutoProxyTask(TaskExecuteBase):
             logger.warning(f"停止 M9A 日志监控失败: {e}")
 
         if self.check_result != "Pass":
+            return
+
+        if self.is_virtual_update_user:
+            try:
+                await self.m9a_process_manager.kill()
+            except Exception as e:
+                logger.warning(f"结束 M9A 进程失败: {e}")
+            try:
+                await System.kill_process(self.m9a_exe_path)
+            except Exception as e:
+                logger.warning(f"强制结束 M9A.exe 失败: {e}")
+
+            if self.cur_user_log.status == "Success!":
+                self.cur_user_item.status = "完成"
+                logger.success(f"虚拟用户 {self.cur_user_uid} M9A 自动更新完成")
+            else:
+                self.cur_user_item.status = "异常"
+                logger.warning(f"虚拟用户 {self.cur_user_uid} M9A 自动更新异常: {self.cur_user_log.status}")
+            logger.info("虚拟用户任务结束")
             return
 
         # 2) 结束 M9A 进程
@@ -597,6 +737,56 @@ class AutoProxyTask(TaskExecuteBase):
             f"M9A 配置构建完成：CurrentTasks={len(config['CurrentTasks'])} 个任务, "
             f"TaskItems={len(config['TaskItems'])} 个任务项"
         )
+        return config
+
+    async def _build_virtual_config(self) -> dict:
+
+        config = {}
+        if self.template_path.exists():
+            try:
+                config = json.loads(self.template_path.read_text(encoding="utf-8"))
+            except Exception:
+                pass
+
+        config.update({
+            "BeforeTask": "None",
+            "AfterTask": "None",
+            "CurrentTasks": [
+                "启动游戏<|||>StartUp",
+                "关闭游戏<|||>Close1999"
+            ],
+            "TaskItems": [
+                {
+                    "name": "启动游戏",
+                    "entry": "StartUp",
+                    "default_check": False,
+                    "controller": ["ADB"]
+                },
+                {
+                    "name": "关闭游戏",
+                    "entry": "Close1999",
+                    "default_check": False,
+                    "controller": ["ADB"]
+                }
+            ],
+            "Resource": config.get("Resource", "官服"),
+            "InstanceName": "MAS-Update",
+            "AutoConnectAfterRefresh": False,
+            "AutoDetectOnConnectionFailed": False,
+            "ContinueRunningWhenError": False,
+            "RememberAdb": False,
+            "RetryOnDisconnected": False,
+            "AllowAdbRestart": False,
+            "AllowAdbHardRestart": False,
+            "AdbControlScreenCapType": "None",
+            "AdbControlInputType": "None",
+            "CurrentControllerName": "ADB",
+            "UI.LiveView.RefreshRate": 10.0,
+            "UI.LiveView.EnableLiveView": True,
+            "AgentTcpMode": True,
+        })
+
+        logger.info("虚拟用户 M9A 配置构建完成")
         return config
 
     @staticmethod

--- a/app/task/M9A/manager.py
+++ b/app/task/M9A/manager.py
@@ -210,11 +210,11 @@ class M9AManager(TaskExecuteBase):
         m9a_exe = Path(self.script_config.get("Info", "Path")) / "M9A.exe"
         await System.kill_process(m9a_exe)
 
-        self.auto_update_fix_enabled = await self._disable_m9a_auto_update()
+        self.auto_update_fix_enabled = self.script_config.get("Run", "IfAutoUpdateAfterQueue")
         if self.auto_update_fix_enabled:
-            logger.info("已关闭 M9A 自动更新，将在批量任务后统一处理")
+            logger.success("已开启队列结束后自动更新，将在批量任务后统一处理")
         else:
-            logger.info("M9A 自动更新未启用或读取失败，无需干预")
+            logger.info("队列结束后自动更新未开启，跳过自动更新处理")
 
     async def main_task(self):
 

--- a/app/task/M9A/manager.py
+++ b/app/task/M9A/manager.py
@@ -21,6 +21,7 @@
 
 
 import uuid
+import json
 import shutil
 from pathlib import Path
 from datetime import datetime
@@ -29,7 +30,7 @@ from app.core import Config, EmulatorManager
 from app.models.task import TaskExecuteBase, ScriptItem, UserItem
 from app.models.ConfigBase import MultipleConfig
 from app.models.config import M9AConfig, M9AUserConfig
-from app.services import Notify
+from app.services import Notify, System
 from app.utils import get_logger
 from app.utils.constants import TASK_MODE_ZH
 from .tools import push_notification
@@ -55,6 +56,12 @@ class M9AManager(TaskExecuteBase):
         self.task_info = script_info.task_info
         self.script_info = script_info
         self.check_result = "-"
+        self.has_new_version = False
+        self.auto_update_fix_enabled = False
+        self.m9a_config_json_path = None
+        self.original_enable_auto_update = None
+        self._virtual_user_old_version = None
+        self._virtual_user_new_version = None
 
     async def check(self) -> str:
         """校验 M9A 配置是否可用"""
@@ -103,6 +110,58 @@ class M9AManager(TaskExecuteBase):
             return "M9A 配置文件不存在或已损坏，请检查 M9A 路径或配置文件情况！"
         return "Pass"
 
+    async def _disable_m9a_auto_update(self):
+        """禁用 M9A 自动更新开关，备份原始值"""
+        if not self.m9a_config_path:
+            return False
+        config_json = self.m9a_config_path / "config.json"
+        if not config_json.exists():
+            return False
+        try:
+            config = json.loads(config_json.read_text(encoding="utf-8"))
+        except Exception:
+            logger.warning("读取 M9A config.json 失败，跳过自动更新控制")
+            return False
+        self.m9a_config_json_path = config_json
+        self.original_enable_auto_update = config.get("EnableAutoUpdateResource", False)
+        if self.original_enable_auto_update:
+            config["EnableAutoUpdateResource"] = False
+            config_json.write_text(json.dumps(config, indent=2, ensure_ascii=False), encoding="utf-8")
+            logger.info("已关闭 M9A 自动更新开关（原值=true），将在批量任务完成后恢复")
+            return True
+        return False
+
+    async def _restore_m9a_auto_update(self):
+        """恢复 M9A 自动更新开关原始值"""
+        if not self.m9a_config_json_path or self.original_enable_auto_update is None:
+            return
+        try:
+            config = json.loads(self.m9a_config_json_path.read_text(encoding="utf-8"))
+            config["EnableAutoUpdateResource"] = self.original_enable_auto_update
+            self.m9a_config_json_path.write_text(json.dumps(config, indent=2, ensure_ascii=False), encoding="utf-8")
+            logger.info("已恢复 M9A 自动更新开关")
+        except Exception as e:
+            logger.exception(f"恢复 M9A 自动更新失败: {e}")
+
+    async def _build_virtual_user_config(self) -> M9AUserConfig:
+        """构建虚拟用户的 M9A 用户配置"""
+
+        config = M9AUserConfig()
+        await config.set("Info", "Name", "M9A自动更新")
+        await config.set("Info", "Status", True)
+        await config.set("Info", "RemainedDay", 999)
+        await config.set("Notify", "Enabled", False)
+        return config
+
+    def _extract_version_info(self):
+        """从首个用户的日志记录中提取 M9A 版本信息"""
+        self._virtual_user_old_version = getattr(
+            self.script_info, '_m9a_current_version', '未知'
+        )
+        self._virtual_user_new_version = getattr(
+            self.script_info, '_m9a_latest_version', '未知'
+        )
+
     async def prepare(self):
         """运行前准备：锁定配置、加载用户、备份原始配置、初始化模拟器"""
         script_id = uuid.UUID(self.script_info.script_id)
@@ -148,6 +207,15 @@ class M9AManager(TaskExecuteBase):
             f"用户列表加载完成, 已筛选用户数: {len(self.script_info.user_list)}"
         )
 
+        m9a_exe = Path(self.script_config.get("Info", "Path")) / "M9A.exe"
+        await System.kill_process(m9a_exe)
+
+        self.auto_update_fix_enabled = await self._disable_m9a_auto_update()
+        if self.auto_update_fix_enabled:
+            logger.info("已关闭 M9A 自动更新，将在批量任务后统一处理")
+        else:
+            logger.info("M9A 自动更新未启用或读取失败，无需干预")
+
     async def main_task(self):
 
         self.check_result = await self.check()
@@ -173,7 +241,58 @@ class M9AManager(TaskExecuteBase):
                 self.user_config,
                 self.emulator_manager,
             )
+            if self.auto_update_fix_enabled and self.script_info.current_index == 0:
+                task.is_first_user_for_version_check = True
+
             await self.spawn(task)
+
+            if self.auto_update_fix_enabled and self.script_info.current_index == 0:
+                self.has_new_version = getattr(self.script_info, '_m9a_has_new_version', False)
+                if not self.has_new_version:
+                    logger.info("首个用户未检测到 M9A 新版本，批量任务完成后将跳过自动更新")
+
+        if self.auto_update_fix_enabled and self.has_new_version:
+            logger.info("检测到 M9A 有新版本，将启动虚拟用户执行自动更新")
+
+            self.script_info._m9a_restart_triggered = False
+            await self._restore_m9a_auto_update()
+
+            virtual_uid_uuid = uuid.uuid5(uuid.NAMESPACE_DNS, "m9a-update.mas.auto")
+            virtual_uid = str(virtual_uid_uuid)
+
+            virtual_user = UserItem(
+                user_id=virtual_uid,
+                name="M9A自动更新",
+                status="等待"
+            )
+            self.script_info.user_list.append(virtual_user)
+
+            virtual_user_config = {
+                virtual_uid_uuid: await self._build_virtual_user_config()
+            }
+
+            self.script_info.current_index = len(self.script_info.user_list) - 1
+
+            virtual_task = METHOD_BOOK[self.task_info.mode](
+                self.script_info,
+                self.script_config,
+                virtual_user_config,
+                self.emulator_manager,
+            )
+            virtual_task.is_virtual_update_user = True
+
+            await self.spawn(virtual_task)
+
+            self._extract_version_info()
+
+            virtual_user_item = self.script_info.user_list[-1]
+            if virtual_user_item.status == "完成":
+                logger.success(f"M9A 自动更新完成: v{self._virtual_user_old_version} → v{self._virtual_user_new_version}")
+            else:
+                logger.warning(f"虚拟用户未正常完成，状态: {virtual_user_item.status}")
+
+        elif self.auto_update_fix_enabled and not self.has_new_version:
+            logger.info("首个用户未检测到 M9A 新版本，跳过自动更新")
 
     async def final_task(self):
         """运行结束后的收尾：解锁配置、推送结果、还原原始配置"""
@@ -233,7 +352,73 @@ class M9AManager(TaskExecuteBase):
                     data={"Error": f"推送代理结果时出现异常: {e}"},
                 )
 
-        # 还原配置：从 temp 恢复原始 config
+            if (
+                getattr(self.script_info, '_m9a_update_success', False)
+                and self._virtual_user_new_version
+                and self._virtual_user_old_version
+            ):
+                update_title = "M9A 资源版本更新"
+                update_message = (
+                    f"M9A 资源版本已从 v{self._virtual_user_old_version} "
+                    f"更新至 v{self._virtual_user_new_version}"
+                )
+                try:
+                    await Notify.push_plyer(update_title, update_message, update_message, 10)
+                except Exception as e:
+                    logger.exception(f"版本更新桌面通知发送失败: {e}")
+
+                update_result = {
+                    "start_time": datetime.now().strftime("%H:%M:%S"),
+                    "end_time": datetime.now().strftime("%H:%M:%S"),
+                    "completed_count": 1,
+                    "uncompleted_count": 0,
+                    "result": update_message,
+                }
+                try:
+                    await push_notification("代理结果", update_title, update_result, None)
+                    logger.info(f"已发送版本更新通知: {update_message}")
+                except Exception as e:
+                    logger.exception(f"版本更新通知发送失败: {e}")
+
+            elif not getattr(self.script_info, '_m9a_update_success', False) and self._virtual_user_old_version:
+                err_log = getattr(self.script_info, '_m9a_err_log', [])
+                virtual_status = "未知错误"
+                full_reason = err_log[-1] if err_log else "无"
+                if getattr(self.script_info, '_m9a_timeout', False):
+                    virtual_status = "更新超时"
+                elif err_log:
+                    last_err = err_log[-1]
+                    if "网络连接中断" in last_err:
+                        virtual_status = "网络连接中断"
+                    elif "HTTP 请求失败" in last_err:
+                        virtual_status = "HTTP 请求失败"
+                    elif "获取资源包下载信息失败" in last_err:
+                        virtual_status = "获取资源包下载信息失败"
+                    elif "进程异常结束" in last_err or "进程异常退出" in last_err:
+                        virtual_status = "进程异常退出"
+                    else:
+                        virtual_status = "未知错误"
+
+                fail_title = "M9A 资源更新失败"
+                fail_message = f"M9A 资源更新失败（{virtual_status}）\n当前版本: v{self._virtual_user_old_version}"
+                try:
+                    await Notify.push_plyer(fail_title, fail_message, fail_message, 10)
+                except Exception as e:
+                    logger.exception(f"版本更新失败桌面通知发送失败: {e}")
+
+                fail_result = {
+                    "start_time": datetime.now().strftime("%H:%M:%S"),
+                    "end_time": datetime.now().strftime("%H:%M:%S"),
+                    "completed_count": 0,
+                    "uncompleted_count": 1,
+                    "result": f"更新失败（{virtual_status}），当前版本: v{self._virtual_user_old_version}",
+                }
+                try:
+                    await push_notification("代理结果", fail_title, fail_result, None)
+                except Exception as e:
+                    logger.exception(f"版本更新失败通知发送失败: {e}")
+                logger.warning(f"M9A 自动更新失败: {virtual_status}（完整原因: {full_reason}）")
+
         if (self.temp_path).exists():
             shutil.rmtree(self.m9a_config_path, ignore_errors=True)
             shutil.copytree(self.temp_path, self.m9a_config_path, dirs_exist_ok=True)

--- a/app/task/M9A/manager.py
+++ b/app/task/M9A/manager.py
@@ -58,8 +58,6 @@ class M9AManager(TaskExecuteBase):
         self.check_result = "-"
         self.has_new_version = False
         self.auto_update_fix_enabled = False
-        self.m9a_config_json_path = None
-        self.original_enable_auto_update = None
         self._virtual_user_old_version = None
         self._virtual_user_new_version = None
 
@@ -110,38 +108,21 @@ class M9AManager(TaskExecuteBase):
             return "M9A 配置文件不存在或已损坏，请检查 M9A 路径或配置文件情况！"
         return "Pass"
 
-    async def _disable_m9a_auto_update(self):
-        """禁用 M9A 自动更新开关，备份原始值"""
+    async def _set_m9a_auto_update(self, enabled: bool):
+        """设置 M9A config.json 中 EnableAutoUpdateResource 的值"""
         if not self.m9a_config_path:
-            return False
+            return
         config_json = self.m9a_config_path / "config.json"
         if not config_json.exists():
-            return False
-        try:
-            config = json.loads(config_json.read_text(encoding="utf-8"))
-        except Exception:
-            logger.warning("读取 M9A config.json 失败，跳过自动更新控制")
-            return False
-        self.m9a_config_json_path = config_json
-        self.original_enable_auto_update = config.get("EnableAutoUpdateResource", False)
-        if self.original_enable_auto_update:
-            config["EnableAutoUpdateResource"] = False
-            config_json.write_text(json.dumps(config, indent=2, ensure_ascii=False), encoding="utf-8")
-            logger.info("已关闭 M9A 自动更新开关（原值=true），将在批量任务完成后恢复")
-            return True
-        return False
-
-    async def _restore_m9a_auto_update(self):
-        """恢复 M9A 自动更新开关原始值"""
-        if not self.m9a_config_json_path or self.original_enable_auto_update is None:
             return
         try:
-            config = json.loads(self.m9a_config_json_path.read_text(encoding="utf-8"))
-            config["EnableAutoUpdateResource"] = self.original_enable_auto_update
-            self.m9a_config_json_path.write_text(json.dumps(config, indent=2, ensure_ascii=False), encoding="utf-8")
-            logger.info("已恢复 M9A 自动更新开关")
-        except Exception as e:
-            logger.exception(f"恢复 M9A 自动更新失败: {e}")
+            config = json.loads(config_json.read_text(encoding="utf-8"))
+            config["EnableAutoUpdateResource"] = enabled
+            config_json.write_text(json.dumps(config, indent=2, ensure_ascii=False), encoding="utf-8")
+            status = "开启" if enabled else "关闭"
+            logger.info(f"已{status} M9A 自动更新开关")
+        except Exception:
+            logger.warning("读写 M9A config.json 失败，跳过自动更新控制")
 
     async def _build_virtual_user_config(self) -> M9AUserConfig:
         """构建虚拟用户的 M9A 用户配置"""
@@ -210,7 +191,7 @@ class M9AManager(TaskExecuteBase):
         m9a_exe = Path(self.script_config.get("Info", "Path")) / "M9A.exe"
         await System.kill_process(m9a_exe)
 
-        await self._disable_m9a_auto_update()
+        await self._set_m9a_auto_update(False)
 
         self.auto_update_fix_enabled = self.script_config.get("Run", "IfAutoUpdateAfterQueue")
         if self.auto_update_fix_enabled:
@@ -257,7 +238,7 @@ class M9AManager(TaskExecuteBase):
             logger.info("检测到 M9A 有新版本，将启动虚拟用户执行自动更新")
 
             self.script_info._m9a_restart_triggered = False
-            await self._restore_m9a_auto_update()
+            await self._set_m9a_auto_update(True)
 
             virtual_uid_uuid = uuid.uuid5(uuid.NAMESPACE_DNS, "m9a-update.mas.auto")
             virtual_uid = str(virtual_uid_uuid)
@@ -292,9 +273,6 @@ class M9AManager(TaskExecuteBase):
                 logger.success(f"M9A 自动更新完成: v{self._virtual_user_old_version} → v{self._virtual_user_new_version}")
             else:
                 logger.warning(f"虚拟用户未正常完成，状态: {virtual_user_item.status}")
-
-        elif self.auto_update_fix_enabled and not self.has_new_version:
-            logger.info("首个用户未检测到 M9A 新版本，跳过自动更新")
 
     async def final_task(self):
         """运行结束后的收尾：解锁配置、推送结果、还原原始配置"""

--- a/app/task/M9A/manager.py
+++ b/app/task/M9A/manager.py
@@ -210,6 +210,8 @@ class M9AManager(TaskExecuteBase):
         m9a_exe = Path(self.script_config.get("Info", "Path")) / "M9A.exe"
         await System.kill_process(m9a_exe)
 
+        await self._disable_m9a_auto_update()
+
         self.auto_update_fix_enabled = self.script_config.get("Run", "IfAutoUpdateAfterQueue")
         if self.auto_update_fix_enabled:
             logger.success("已开启队列结束后自动更新，将在批量任务后统一处理")

--- a/frontend/src/types/script.ts
+++ b/frontend/src/types/script.ts
@@ -131,6 +131,7 @@ export interface M9AScriptConfig {
     ProxyTimesLimit: number
     RunTimesLimit: number
     RunTimeLimit: number
+    IfAutoUpdateAfterQueue: boolean
   }
   SubConfigsInfo: {
     UserData: {

--- a/frontend/src/views/EditView/Script/M9AScriptEdit.vue
+++ b/frontend/src/views/EditView/Script/M9AScriptEdit.vue
@@ -175,6 +175,25 @@
               </a-form-item>
             </a-col>
           </a-row>
+          <a-row :gutter="24" style="margin-top: 16px">
+            <a-col :span="8">
+              <a-form-item>
+                <template #label>
+                  <a-tooltip title="开启后，当此脚本在调度队列中运行时，所有用户任务完成后将自动更新M9A资源版本，须提前手动打开M9A应用配置更新源">
+                    <span class="form-label">
+                      队列结束后自动更新
+                      <QuestionCircleOutlined class="help-icon" />
+                    </span>
+                  </a-tooltip>
+                </template>
+                <a-select v-model:value="m9aConfig.Run.IfAutoUpdateAfterQueue" size="large"
+                  @change="handleChange('Run', 'IfAutoUpdateAfterQueue', $event)">
+                  <a-select-option :value="true">是</a-select-option>
+                  <a-select-option :value="false">否</a-select-option>
+                </a-select>
+              </a-form-item>
+            </a-col>
+          </a-row>
         </div>
 
       </a-form>
@@ -228,6 +247,7 @@ const m9aConfig = reactive<M9AScriptConfig>({
     ProxyTimesLimit: 0,
     RunTimesLimit: 3,
     RunTimeLimit: 30,
+    IfAutoUpdateAfterQueue: false,
   },
   Emulator: {
     Id: '',


### PR DESCRIPTION
# M9A 批量任务自动更新 — 虚拟用户方案

## 概述

实现 M9A 批量任务自动更新功能。

**背景**：M9A 的资源自动更新机制需要 M9A 在任务运行结束后的空闲时间才会触发，但 MAS 在真实用户任务完成后会直接关闭 M9A 进程，导致 M9A 自身的自动更新机制无法生效。

**方案**：在所有真实用户任务完成后，动态追加一个"虚拟用户"专门执行 M9A 资源更新。虚拟用户使用最小化配置启动 M9A，仅让 M9A 保持运行以触发其自动更新机制，通过日志监控确认更新结果并推送版本变更通知。

**方案特点**：
- **前端开关控制**：脚本编辑页「运行配置」新增"队列结束后自动更新"下拉选项（是/否），控制是否创建虚拟用户执行更新
- **运行时 M9A 保护**：运行期间关闭 M9A 自身的 `EnableAutoUpdateResource`，虚拟用户前打开
- **全量配置兜底**：M9A `config/` 目录在 prepare() 阶段全量备份，final_task() 全量还原，确保运行前后完全一致
- **无侵入**：不影响现有批量任务的正常执行路径和通知流程

## 流程

```mermaid
flowchart TD
    A["prepare()<br>① 全量备份 M9A config/ → temp<br>② Kill 旧 M9A 进程<br>③ _set_m9a_auto_update(False)<br>④ 读取 IfAutoUpdateAfterQueue 开关"] --> B["循环执行真实用户<br>（期间 M9A 自动更新关闭）"]

    B --> C["首个用户: is_first_user_for_version_check --> 检测 has_new_version"]
    C --> D["继续执行其余真实用户"]

    D --> E{"auto_update_fix_enabled<br>&&<br>has_new_version?"}
    E -->|否| F["跳过，记录日志"]

    E -->|是| G["_set_m9a_auto_update(True)<br>开启 EnableAutoUpdateResource"]
    G --> H["构造虚拟 UserItem"]
    H --> I["创建 AutoProxyTask<br>is_virtual_update_user=True"]
    I --> J["spawn() → M9A 启动<br>自行检测/下载/更新"]

    J --> K{"日志监控"}
    K --> L["检测到: 准备重新启动应用"]
    L --> M["_m9a_restart_triggered = True<br>进程正常退出"]
    M --> N["_m9a_update_success = True"]

    K --> O["[ERR] 日志 / 特定失败"]
    O --> P["写入 _m9a_err_log"]

    K --> Q["超时 600s"]
    Q --> R["标记超时"]

    N --> S["final_task()"]
    P --> S
    R --> S

    S --> T{"更新成功?"}
    T -->|是| U["桌面通知 + 推送通知<br>v旧版本 → v新版本"]
    T -->|否| V["分类失败原因<br>推送失败通知"]

    S --> W["从 temp 全量还原 M9A config/<br>（config.json 恢复原始值）"]
```

## 队列结束后自动更新开关

### 前端

脚本编辑页「运行配置」区域新增"队列结束后自动更新"选项：

- **类型**：下拉选择框（是/否）
- **默认值**：否
- **提示**：开启后，当此脚本在调度队列中运行时，所有用户任务完成后将自动更新M9A资源版本
- **位置**：M9AScriptEdit.vue 运行配置区域

### 数据流

```
前端 Select → API 请求 → Pydantic M9AConfig_Run schema → Config.update_script() → 保存到文件
                                                                                      ↓
前端 Object.assign(m9aConfig, config) ← API 响应 ← Pydantic M9AConfig_Run schema ← Config.get_script()
```

### 配置模型

```python
## M9AConfig (config.py)
self.Run_IfAutoUpdateAfterQueue = ConfigItem(
    "Run", "IfAutoUpdateAfterQueue", False, BoolValidator()
)

## M9AConfig_Run (schema.py)
IfAutoUpdateAfterQueue: Optional[bool] = Field(
    default=None, description="是否在队列结束后自动更新M9A"
)
```

## manager.py

### 属性

| 属性 | 说明 |
|------|------|
| `has_new_version` | 首批用户是否检测到 M9A 新版本 |
| `auto_update_fix_enabled` | 自动更新是否启用（由 `IfAutoUpdateAfterQueue` 开关控制） |
| `_virtual_user_old_version` | 旧版本号（从首用户日志提取） |
| `_virtual_user_new_version` | 新版本号（从首用户日志提取） |

### 方法

#### `_set_m9a_auto_update(enabled: bool)`

设置 M9A `config.json` 中 `EnableAutoUpdateResource` 的值，不做备份。调用方需保证调用时机正确：
- `prepare()` 传入 `False` — 运行期间关闭
- `main_task()` 虚拟用户前传入 `True` — 打开使 M9A 可自行更新

#### `_build_virtual_user_config() -> M9AUserConfig`

构造虚拟用户的最小化配置：Name 设为 `"M9A自动更新"`，禁用通知推送，其余字段取默认值。

#### `_extract_version_info()`

从 `script_info._m9a_current_version` 和 `_m9a_latest_version` 中提取版本号，用于更新通知。

### 修改方法

#### `prepare()` — 启动前准备

```python
# 杀旧进程
m9a_exe = Path(self.script_config.get("Info", "Path")) / "M9A.exe"
await System.kill_process(m9a_exe)

# 关闭 M9A 自动更新（运行期间保持关闭）
await self._set_m9a_auto_update(False)

# 开关决定是否在队列结束后创建虚拟用户执行更新
self.auto_update_fix_enabled = self.script_config.get("Run", "IfAutoUpdateAfterQueue")
if self.auto_update_fix_enabled:
    logger.success("已开启队列结束后自动更新，将在批量任务后统一处理")
else:
    logger.info("队列结束后自动更新未开启，跳过自动更新处理")
```

#### `main_task()` — 核心调度逻辑

1. **首个用户版本检测**：`current_index == 0` + `auto_update_fix_enabled 时设置 `is_first_user_for_version_check = True`
2. **首个用户完成后**：读取 `_m9a_has_new_version`，若为 False 则记录跳过日志
3. **所有用户完成后**：
   - 开关 ON + 有新版本：`_set_m9a_auto_update(True)` 开启 → 构造虚拟用户 → spawn → 等待完成 → 提取版本信息
   - 其他情况：跳过

#### `final_task()` — 收尾与通知

在原有通知逻辑后新增版本更新通知。最后从 temp 备份全量还原 M9A `config/` 目录：

```python
if (self.temp_path).exists():
    shutil.rmtree(self.m9a_config_path, ignore_errors=True)
    shutil.copytree(self.temp_path, self.m9a_config_path, dirs_exist_ok=True)
shutil.rmtree(self.temp_path, ignore_errors=True)
```

这确保 `config.json`（以及整个 config 目录）恢复为运行前的原始状态。

---

## AutoProxy.py

### 属性

| 属性 | 说明 |
|------|------|
| `is_first_user_for_version_check` | 首个用户标志，启用版本检测 |
| `is_virtual_update_user` | 虚拟用户标志，启用更新监控 |

### 方法

#### `_build_virtual_config() -> dict`

构建虚拟用户的最小化 M9A instances 配置：
- `BeforeTask="None"`、`AfterTask="None"` — 不触发模拟器启停
- `CurrentTasks` 仅含"启动游戏"和"关闭游戏"两个最简任务
- `InstanceName="MAS-Update"` — 标识虚拟用户实例
- 复用 `default.json` 模板中的 `Resource` 和 `AdbDevice`

### 修改方法

#### `check()` — 跳过虚拟用户配置校验

虚拟用户直接返回 `"Pass"`，不需要校验 M9A 配置完整性。

#### `main_task()` — 分流构建配置

```python
if self.is_virtual_update_user:
    config = await self._build_virtual_config()
else:
    config = await self.build_config(queue, ...)
```

#### `check_log()` — 三阶段日志监控

**第一阶段：版本检测（仅首个用户）**
- 检测 `检测到资源有新版本` → 设置 `_m9a_has_new_version = True`
- 提取 `当前资源版本：vX.Y.Z` → `_m9a_current_version`
- 提取 `最新资源版本：vX.Y.Z` → `_m9a_latest_version`

**第二阶段：任务结果判断（所有用户）** — 保持不变

**第三阶段：虚拟用户更新监控**
- `准备重新启动应用` → 标记 `_m9a_restart_triggered = True`
- `[ERR]` 日志收集 → 写入 `_m9a_err_log`
- 特定失败检测：获取资源包下载信息失败 / 网络连接中断 / HTTP 请求失败
- 超时检测：600 秒（10 分钟）
- 进程状态监控：`_restart_triggered` 为 True 时正常退出视为更新成功，未触发重启退出视为异常

#### `final_task()` — 虚拟用户专属清理

虚拟用户仅杀 M9A 进程，不处理模拟器和游戏，不推送常规代理结果。