### PR TITLE
feat(M9A): M9A 用户编辑页全面体验优化 — 服务器适配、账号切换、UI 重构、预设模板

### DIFF
--- a/app/models/config.py
+++ b/app/models/config.py
@@ -1333,6 +1333,8 @@ class M9AUserConfig(ConfigBase):
         self.Info_Tag = ConfigItem(
             "Info", "Tag", "[ ]", VirtualConfigValidator(self.getTags)
         )
+        ## 服务器资源
+        self.Info_Resource = ConfigItem("Info", "Resource", "官服")
 
         ## Task -------------------------------------------------------------
         ## 可用任务列表（从 M9A 配置文件读取）

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -1335,6 +1335,8 @@ class M9AUserConfig(ConfigBase):
         )
         ## 服务器资源
         self.Info_Resource = ConfigItem("Info", "Resource", "官服")
+        ## 账号信息（用于切换账号）
+        self.Info_Account = ConfigItem("Info", "Account", "")
 
         ## Task -------------------------------------------------------------
         ## 可用任务列表（从 M9A 配置文件读取）

--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -849,6 +849,7 @@ class M9AUserConfig_Info(BaseModel):
     Notes: Optional[str] = Field(default=None, description="备注")
     Tag: Optional[str] = Field(default=None, description="用户标签信息")
     Resource: Optional[str] = Field(default=None, description="服务器资源名称")
+    Account: Optional[str] = Field(default=None, description="账号信息（用于切换账号，仅官服生效）")
 
 
 class M9AUserConfig_Task(BaseModel):

--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -848,6 +848,7 @@ class M9AUserConfig_Info(BaseModel):
     RemainedDay: Optional[int] = Field(default=None, description="剩余天数")
     Notes: Optional[str] = Field(default=None, description="备注")
     Tag: Optional[str] = Field(default=None, description="用户标签信息")
+    Resource: Optional[str] = Field(default=None, description="服务器资源名称")
 
 
 class M9AUserConfig_Task(BaseModel):

--- a/app/task/M9A/AutoProxy.py
+++ b/app/task/M9A/AutoProxy.py
@@ -184,6 +184,7 @@ class AutoProxyTask(TaskExecuteBase):
             # 读取用户队列
             queue = self.cur_user_config.get("Task", "Queue")
             resource = self.cur_user_config.get("Info", "Resource") or "官服"
+            account = self.cur_user_config.get("Info", "Account") or ""
             logger.info(f"用户 {self.cur_user_uid} 的任务队列 (原始): {queue}, 类型: {type(queue)}")
 
             # 确保 queue 是列表
@@ -200,10 +201,14 @@ class AutoProxyTask(TaskExecuteBase):
                 self.cur_user_item.status = "异常"
                 return
 
+            # 清理保留任务（二次兜底）
+            RESERVED_NAMES = {"启动游戏", "关闭游戏", "切换账号"}
+            queue = [item for item in queue if (item if isinstance(item, str) else item.get("name", "")) not in RESERVED_NAMES]
+
             logger.info(f"用户 {self.cur_user_uid} 将执行 {len(queue)} 个任务: {queue}")
 
             # 写入M9A配置
-            await self.write_m9a_config(queue, emulator_info, resource)
+            await self.write_m9a_config(queue, emulator_info, resource, account)
 
             # 启动 M9A
             logger.info(f"启动 M9A 进程：{self.m9a_exe_path}")
@@ -258,7 +263,7 @@ class AutoProxyTask(TaskExecuteBase):
 
                 await asyncio.sleep(3)
 
-    async def write_m9a_config(self, queue: list, emulator_info: DeviceInfo, resource: str = "官服"):
+    async def write_m9a_config(self, queue: list, emulator_info: DeviceInfo, resource: str = "官服", account: str = ""):
         """向 M9A 目录写入运行配置文件，并保存 debug 备份"""
         logger.info("开始配置 M9A 运行参数")
 
@@ -279,7 +284,8 @@ class AutoProxyTask(TaskExecuteBase):
                 script_config=self.script_config,
                 emulator_index=emulator_index,
                 emulator_manager=self.emulator_manager,
-                resource=resource
+                resource=resource,
+                account=account
             )
         except Exception as e:
             logger.error(f"构建 M9A 配置失败: {e}")
@@ -500,7 +506,8 @@ class AutoProxyTask(TaskExecuteBase):
         script_config: M9AConfig | None = None,
         emulator_index: str | None = None,
         emulator_manager = None,
-        resource: str = "官服"
+        resource: str = "官服",
+        account: str = ""
     ) -> dict:
         config = None
 
@@ -541,6 +548,22 @@ class AutoProxyTask(TaskExecuteBase):
         logger.info(f"M9A CurrentTasks：共 {len(config['CurrentTasks'])} 个任务")
 
         config["TaskItems"] = []
+
+        # 自动添加启动游戏（队列首）
+        startup_def = task_loader.get_full_definition("启动游戏")
+        if startup_def:
+            config["TaskItems"].append(self._build_task_item(startup_def, default_check=True))
+
+        # 如果官服且填写了账号信息，插入切换账号
+        if resource == "官服" and account:
+            switch_account_def = task_loader.get_full_definition("切换账号")
+            if switch_account_def:
+                switch_item = self._build_task_item(switch_account_def, default_check=True)
+                for opt in (switch_item.get("option") or []):
+                    if opt.get("name") == "目标账号(可选)":
+                        opt["data"] = {"账号": account}
+                config["TaskItems"].append(switch_item)
+
         skipped_standalone = 0
 
         for queue_item in queue:
@@ -563,6 +586,11 @@ class AutoProxyTask(TaskExecuteBase):
 
             item = self._build_task_item(task_def, default_check=True, user_options=task_options)
             config["TaskItems"].append(item)
+
+        # 自动添加关闭游戏（队列尾）
+        close_def = task_loader.get_full_definition("关闭游戏")
+        if close_def:
+            config["TaskItems"].append(self._build_task_item(close_def, default_check=True))
 
         logger.info(
             f"M9A TaskItems：共 {len(config['TaskItems'])} 个任务项"

--- a/app/task/M9A/AutoProxy.py
+++ b/app/task/M9A/AutoProxy.py
@@ -183,6 +183,7 @@ class AutoProxyTask(TaskExecuteBase):
 
             # 读取用户队列
             queue = self.cur_user_config.get("Task", "Queue")
+            resource = self.cur_user_config.get("Info", "Resource") or "官服"
             logger.info(f"用户 {self.cur_user_uid} 的任务队列 (原始): {queue}, 类型: {type(queue)}")
 
             # 确保 queue 是列表
@@ -202,7 +203,7 @@ class AutoProxyTask(TaskExecuteBase):
             logger.info(f"用户 {self.cur_user_uid} 将执行 {len(queue)} 个任务: {queue}")
 
             # 写入M9A配置
-            await self.write_m9a_config(queue, emulator_info)
+            await self.write_m9a_config(queue, emulator_info, resource)
 
             # 启动 M9A
             logger.info(f"启动 M9A 进程：{self.m9a_exe_path}")
@@ -257,7 +258,7 @@ class AutoProxyTask(TaskExecuteBase):
 
                 await asyncio.sleep(3)
 
-    async def write_m9a_config(self, queue: list, emulator_info: DeviceInfo):
+    async def write_m9a_config(self, queue: list, emulator_info: DeviceInfo, resource: str = "官服"):
         """向 M9A 目录写入运行配置文件，并保存 debug 备份"""
         logger.info("开始配置 M9A 运行参数")
 
@@ -277,7 +278,8 @@ class AutoProxyTask(TaskExecuteBase):
                 emulator_id=emulator_id,
                 script_config=self.script_config,
                 emulator_index=emulator_index,
-                emulator_manager=self.emulator_manager
+                emulator_manager=self.emulator_manager,
+                resource=resource
             )
         except Exception as e:
             logger.error(f"构建 M9A 配置失败: {e}")
@@ -497,13 +499,15 @@ class AutoProxyTask(TaskExecuteBase):
         emulator_id: str | None = None,
         script_config: M9AConfig | None = None,
         emulator_index: str | None = None,
-        emulator_manager = None
+        emulator_manager = None,
+        resource: str = "官服"
     ) -> dict:
         config = None
 
         if self.template_path.exists():
             try:
                 config = json.loads(self.template_path.read_text(encoding="utf-8"))
+                config["Resource"] = resource
                 logger.info(f"使用配置模板：{self.template_path}")
             except Exception as e:
                 logger.warning(f"读取模板 {self.template_path} 失败：{e}")
@@ -511,7 +515,7 @@ class AutoProxyTask(TaskExecuteBase):
         if config is None:
             logger.warning("无法读取配置模板，使用最小默认配置")
             config = {
-                "Resource": "官服",
+                "Resource": resource,
                 "CurrentTasks": [],
                 "TaskItems": [],
                 "AdbDevice": {

--- a/frontend/src/components/ScriptTable.vue
+++ b/frontend/src/components/ScriptTable.vue
@@ -132,6 +132,11 @@
                               getServerDisplayName(user.Info.Server) }}
                           </a-tag>
 
+                          <!-- M9A 脚本显示服务器标签 -->
+                          <a-tag v-if="script.type === 'M9A'" :color="getM9AServerTagColor(user.Info.Resource)" class="server-tag">
+                            {{ user.Info.Resource || '官服' }}
+                          </a-tag>
+
                           <!-- 账号标签 -->
                           <a-tag v-if="
                             script.type === 'MAA' ||
@@ -175,6 +180,20 @@
                           <!-- 直接使用后端提供的Tag字段 -->
                           <a-tag v-for="(tag, index) in parseStatusTagList(user.Info.Tag)" :key="index"
                             :title="tag.text" class="info-tag" :color="tag.color">
+                            {{ tag.text }}
+                          </a-tag>
+                        </div>
+                        <!-- 用户详细信息 - M9A脚本用户 -->
+                        <div v-if="script.type === 'M9A'" class="user-info-tags">
+                          <!-- 显示备注（仅当有值时）-->
+                          <a-tag v-if="user.Info.Notes && user.Info.Notes !== '无' && user.Info.Notes.trim() !== ''"
+                                 color="geekblue" class="info-tag" :title="user.Info.Notes">
+                            {{ truncateText(user.Info.Notes, 10) }}
+                          </a-tag>
+
+                          <!-- 后端提供的Tag字段 -->
+                          <a-tag v-for="(tag, index) in parseStatusTagList(user.Info.Tag)" :key="index"
+                                 :title="tag.text" class="info-tag" :color="tag.color">
                             {{ tag.text }}
                           </a-tag>
                         </div>
@@ -569,6 +588,27 @@ const getServerDisplayName = (server: string): string => {
     default:
       return server || '未知'
   }
+}
+
+// M9A服务器标签颜色映射
+const getM9AServerTagColor = (_resource: string): string => {
+  return 'blue'
+}
+
+// M9A剩余天数颜色（智能着色）
+const getM9ARemainedDayColor = (remainedDay: number): string => {
+  if (remainedDay === -1) return 'gold'
+  if (remainedDay === 0) return 'red'
+  if (remainedDay <= 3) return 'orange'
+  if (remainedDay <= 7) return 'yellow'
+  return 'blue'
+}
+
+// M9A剩余天数友好文本
+const getM9ARemainedDayText = (remainedDay: number): string => {
+  if (remainedDay === -1) return '长期有效'
+  if (remainedDay === 0) return '已到期'
+  return `${remainedDay}天`
 }
 
 // 获取基建模式显示名称

--- a/frontend/src/composables/useScriptApi.ts
+++ b/frontend/src/composables/useScriptApi.ts
@@ -733,6 +733,14 @@ export function useScriptApi() {
                         Notes:
                           m9aUserData.Info?.Notes !== undefined ? m9aUserData.Info.Notes : '',
                         Tag: m9aUserData.Info?.Tag !== undefined ? m9aUserData.Info.Tag : null,
+                        Resource:
+                          m9aUserData.Info?.Resource !== undefined
+                            ? m9aUserData.Info.Resource
+                            : '官服',
+                        Account:
+                          m9aUserData.Info?.Account !== undefined
+                            ? m9aUserData.Info.Account
+                            : '',
                         EmulatorId:
                           m9aUserData.Info?.EmulatorId !== undefined
                             ? m9aUserData.Info.EmulatorId

--- a/frontend/src/views/EditView/Script/M9AScriptEdit.vue
+++ b/frontend/src/views/EditView/Script/M9AScriptEdit.vue
@@ -179,6 +179,21 @@
 
       </a-form>
     </a-card>
+
+    <!-- M9A 配置指南（页面底部常驻提示） -->
+    <div class="guide-footer">
+      <div class="guide-footer-content">
+        <img src="@/assets/M9A.png" alt="M9A" class="guide-logo" />
+        <div class="guide-message">
+          <span class="guide-text">提醒您：阁下若是遇到了难题，不妨查看</span>
+          <a href="https://doc.auto-mas.top/docs/script-guide/m9a.html"
+             target="_blank" class="guide-link">
+            M9A 官方配置指南
+          </a>
+          <span class="guide-text">，其中清晰写明了所有配置步骤。</span>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -194,6 +209,7 @@ import {
   ArrowLeftOutlined,
   FolderOpenOutlined,
   QuestionCircleOutlined,
+  BookOutlined,
 } from '@ant-design/icons-vue'
 
 const logger = window.electronAPI.getLogger('M9A脚本编辑')
@@ -790,5 +806,60 @@ const selectM9APath = async () => {
 .float-button {
   width: 60px;
   height: 60px;
+}
+
+.guide-footer {
+  margin-top: 32px;
+  padding: 20px 28px;
+  background: linear-gradient(135deg, rgba(19, 194, 194, 0.06), rgba(19, 194, 194, 0.02));
+  border: 1px solid rgba(19, 194, 194, 0.2);
+  border-radius: 12px;
+  animation: fadeInUp 0.6s ease-out;
+}
+
+.guide-footer-content {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.guide-logo {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+  flex-shrink: 0;
+  filter: drop-shadow(0 2px 4px rgba(19, 194, 194, 0.3));
+}
+
+.guide-message {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px;
+  font-size: 14px;
+  line-height: 1.8;
+  color: var(--ant-color-text-secondary);
+}
+
+.guide-text {
+  color: var(--ant-color-text-secondary);
+}
+
+.guide-link {
+  font-size: 14px;
+  font-weight: 600;
+  color: #13c2c2 !important;
+  padding: 0 2px;
+  line-height: inherit;
+  vertical-align: baseline;
+  display: inline;
+  transition: all 0.2s ease;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.guide-link:hover {
+  color: #36cfc9 !important;
+  text-decoration: underline;
 }
 </style>

--- a/frontend/src/views/EditView/User/M9AUserEdit.vue
+++ b/frontend/src/views/EditView/User/M9AUserEdit.vue
@@ -62,6 +62,7 @@ const getDefaultM9AUserData = () => ({
     Notes: '',
     Tag: '',
     Resource: '官服',
+    Account: '',
   },
   Task: {
     AvailableTasks: '[]',
@@ -225,7 +226,11 @@ const loadUserData = async () => {
 
           if (userData.Task?.Queue) {
             try {
-              taskQueue.value = JSON.parse(userData.Task.Queue)
+              const RESERVED_TASK_NAMES = ['启动游戏', '关闭游戏', '切换账号']
+              const parsedQueue = JSON.parse(userData.Task.Queue)
+              taskQueue.value = parsedQueue.filter(
+                (item: M9ATaskQueueItem) => !RESERVED_TASK_NAMES.includes(item.name)
+              )
             } catch (e) {
               taskQueue.value = []
             }

--- a/frontend/src/views/EditView/User/M9AUserEdit.vue
+++ b/frontend/src/views/EditView/User/M9AUserEdit.vue
@@ -61,6 +61,7 @@ const getDefaultM9AUserData = () => ({
     RemainedDay: -1,
     Notes: '',
     Tag: '',
+    Resource: '官服',
   },
   Task: {
     AvailableTasks: '[]',

--- a/frontend/src/views/M9AUserEdit/BasicInfoSection.vue
+++ b/frontend/src/views/M9AUserEdit/BasicInfoSection.vue
@@ -39,21 +39,6 @@
 
     <a-row :gutter="24">
       <a-col :span="12">
-        <a-form-item name="remainedDay">
-          <template #label>
-            <a-tooltip title="账号剩余的有效天数，「-1」表示无限">
-              <span class="form-label">
-                剩余天数
-                <QuestionCircleOutlined class="help-icon" />
-              </span>
-            </a-tooltip>
-          </template>
-          <a-input-number v-model:value="formData.Info.RemainedDay" :min="-1" :max="9999" placeholder="0"
-            :disabled="loading" size="large" style="width: 100%"
-            @blur="emitSave('Info.RemainedDay', formData.Info.RemainedDay)" />
-        </a-form-item>
-      </a-col>
-      <a-col :span="12">
         <a-form-item name="resource">
           <template #label>
             <a-tooltip title="选择当前用户使用的游戏服务器">
@@ -71,6 +56,50 @@
             :options="resourceOptions"
             @change="emitSave('Info.Resource', formData.Info.Resource)"
           />
+        </a-form-item>
+      </a-col>
+      <a-col :span="12">
+        <a-form-item name="account">
+          <template #label>
+            <a-tooltip>
+              <template #title>
+                <div style="max-width: 260px; white-space: normal;">
+                  填写目标账号时会在账号列表中逐页下滑查找并切换，找不到则任务失败<br><br>
+                  目前该功能仅支持官服，且仅支持 1280×720 实际未缩放分辨率
+                </div>
+              </template>
+              <span class="form-label">
+                账号信息
+                <QuestionCircleOutlined class="help-icon" />
+              </span>
+            </a-tooltip>
+          </template>
+          <a-input
+            v-model:value="formData.Info.Account"
+            placeholder="留空则不切换账号"
+            :disabled="loading"
+            size="large"
+            class="modern-input"
+            @blur="emitSave('Info.Account', formData.Info.Account)"
+          />
+        </a-form-item>
+      </a-col>
+    </a-row>
+
+    <a-row :gutter="24">
+      <a-col :span="12">
+        <a-form-item name="remainedDay">
+          <template #label>
+            <a-tooltip title="账号剩余的有效天数，「-1」表示无限">
+              <span class="form-label">
+                剩余天数
+                <QuestionCircleOutlined class="help-icon" />
+              </span>
+            </a-tooltip>
+          </template>
+          <a-input-number v-model:value="formData.Info.RemainedDay" :min="-1" :max="9999" placeholder="0"
+            :disabled="loading" size="large" style="width: 100%"
+            @blur="emitSave('Info.RemainedDay', formData.Info.RemainedDay)" />
         </a-form-item>
       </a-col>
     </a-row>

--- a/frontend/src/views/M9AUserEdit/BasicInfoSection.vue
+++ b/frontend/src/views/M9AUserEdit/BasicInfoSection.vue
@@ -53,6 +53,26 @@
             @blur="emitSave('Info.RemainedDay', formData.Info.RemainedDay)" />
         </a-form-item>
       </a-col>
+      <a-col :span="12">
+        <a-form-item name="resource">
+          <template #label>
+            <a-tooltip title="选择当前用户使用的游戏服务器">
+              <span class="form-label">
+                服务器
+                <QuestionCircleOutlined class="help-icon" />
+              </span>
+            </a-tooltip>
+          </template>
+          <a-select
+            v-model:value="formData.Info.Resource"
+            placeholder="请选择服务器"
+            :disabled="loading"
+            size="large"
+            :options="resourceOptions"
+            @change="emitSave('Info.Resource', formData.Info.Resource)"
+          />
+        </a-form-item>
+      </a-col>
     </a-row>
 
     <a-form-item name="notes">
@@ -72,6 +92,18 @@
 
 <script setup lang="ts">
 import { QuestionCircleOutlined } from '@ant-design/icons-vue'
+
+const resourceOptions = [
+  { label: '官服', value: '官服' },
+  { label: 'B 服', value: 'B 服' },
+  { label: 'OPPO 服', value: 'OPPO 服' },
+  { label: '小米服', value: '小米服' },
+  { label: '华为服', value: '华为服' },
+  { label: '国际服（EN）', value: '国际服（EN）' },
+  { label: '国际服（JP）', value: '国际服（JP）' },
+  { label: '港澳台服', value: '港澳台服' },
+  { label: '国际服（KR）', value: '国际服（KR）' },
+]
 
 defineProps<{
   formData: any

--- a/frontend/src/views/M9AUserEdit/BasicInfoSection.vue
+++ b/frontend/src/views/M9AUserEdit/BasicInfoSection.vue
@@ -150,12 +150,12 @@ const emitSave = (key: string, value: any) => {
 
 <style scoped>
 .form-section {
-  margin-bottom: 32px;
+  margin-bottom: 40px;
 }
 
 .section-header {
-  margin-bottom: 20px;
-  padding-bottom: 8px;
+  margin-bottom: 24px;
+  padding-bottom: 12px;
   border-bottom: 2px solid var(--ant-color-border-secondary);
   display: flex;
   justify-content: space-between;
@@ -212,7 +212,7 @@ const emitSave = (key: string, value: any) => {
 
 .modern-input:focus,
 .modern-input.ant-input-focused {
-  border-color: var(--ant-color-primary);
-  box-shadow: 0 0 0 4px rgba(24, 144, 255, 0.1);
+  border-color: #13c2c2;
+  box-shadow: 0 0 0 4px rgba(19, 194, 194, 0.15);
 }
 </style>

--- a/frontend/src/views/M9AUserEdit/NotifyConfigSection.vue
+++ b/frontend/src/views/M9AUserEdit/NotifyConfigSection.vue
@@ -83,12 +83,12 @@ const handleWebhookChange = () => {
 
 <style scoped>
 .form-section {
-  margin-bottom: 32px;
+  margin-bottom: 40px;
 }
 
 .section-header {
-  margin-bottom: 20px;
-  padding-bottom: 8px;
+  margin-bottom: 24px;
+  padding-bottom: 12px;
   border-bottom: 2px solid var(--ant-color-border-secondary);
   display: flex;
   justify-content: space-between;
@@ -114,9 +114,10 @@ const handleWebhookChange = () => {
 }
 
 .switch-description {
-  margin-left: 12px;
-  font-size: 13px;
+  margin-left: 16px;
+  font-size: 14px;
   color: var(--ant-color-text-secondary);
+  line-height: 1.6;
 }
 
 .modern-input {

--- a/frontend/src/views/M9AUserEdit/TaskQueueSection.vue
+++ b/frontend/src/views/M9AUserEdit/TaskQueueSection.vue
@@ -189,8 +189,13 @@ const loadAvailableTasks = async () => {
       availableTasks.value = []
       taskDefinitions.value = {}
       
+      const RESERVED_ENTRIES = ['StartUp', 'Close1999', 'SwitchAccount']
+
       response.data.forEach((task: any) => {
-        if (!task.group || !task.group.includes('standalone')) {
+        if (
+          (!task.group || !task.group.includes('standalone')) &&
+          !RESERVED_ENTRIES.includes(task.entry)
+        ) {
           availableTasks.value.push(task)
           taskDefinitions.value[task.name] = task
         }

--- a/frontend/src/views/M9AUserEdit/TaskQueueSection.vue
+++ b/frontend/src/views/M9AUserEdit/TaskQueueSection.vue
@@ -24,7 +24,51 @@
         </div>
         
         <div class="task-list">
+          <!-- 预设模板区域（队列为空时显示） -->
+          <div v-if="localTaskQueue.length === 0" class="preset-section">
+            <div class="preset-card">
+              <div class="preset-card-inner">
+                <div class="preset-header">
+                  <div class="preset-icon-wrap">
+                    <span class="preset-icon">📋</span>
+                  </div>
+                  <div class="preset-info">
+                    <h3 class="preset-name">{{ dailyPreset.name }}</h3>
+                    <p class="preset-desc">{{ dailyPreset.description }}</p>
+                  </div>
+                  <div class="preset-badge">
+                    <a-tag :color="matchedCount > 0 ? 'processing' : 'default'">
+                      {{ matchedCount }}/{{ dailyPreset.taskNames.length }} 可用
+                    </a-tag>
+                  </div>
+                </div>
+
+                <div class="preset-tasks-preview">
+                  <div class="task-chip" v-for="(item, idx) in matchedTasks" :key="idx">
+                    <span class="task-dot" :class="{ 'task-dot-miss': !item.matched }"></span>
+                    <span class="task-name" :class="{ 'task-name-miss': !item.matched }">{{ item.name }}</span>
+                    <CheckCircleFilled v-if="item.matched" class="task-check" />
+                    <CloseCircleFilled v-else class="task-check task-check-miss" />
+                  </div>
+                </div>
+
+                <div class="preset-actions">
+                  <a-button type="primary" size="large" block :loading="addingFromPreset"
+                    :disabled="matchedCount === 0"
+                    @click="addFromPreset">
+                    <template #icon><ThunderboltOutlined /></template>
+                    一键添加 {{ matchedCount }} 个任务
+                  </a-button>
+                  <p v-if="matchedCount < dailyPreset.taskNames.length" class="preset-hint">
+                    部分任务未找到对应脚本，已自动跳过
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+
           <draggable
+            v-else
             v-model="localTaskQueue"
             item-key="name"
             :animation="200"
@@ -101,7 +145,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, nextTick, watch } from 'vue'
-import { PlusOutlined, UpOutlined, DownOutlined, DeleteOutlined } from '@ant-design/icons-vue'
+import { PlusOutlined, UpOutlined, DownOutlined, DeleteOutlined, ThunderboltOutlined, CheckCircleFilled, CloseCircleFilled } from '@ant-design/icons-vue'
 import { message } from 'ant-design-vue'
 import draggable from 'vuedraggable'
 import { Service } from '@/api'
@@ -126,6 +170,40 @@ const selectedTaskIndex = ref<number | null>(null)
 const taskDefinitions = ref<Record<string, any>>({})
 const localTaskQueue = ref<M9ATaskQueueItem[]>([])
 const isDragging = ref(false)
+
+// 预设模板常量
+const dailyPreset = {
+  name: '日常-长草',
+  description: '无活动或换完商店时使用，进行常规刷取',
+  taskNames: [
+    '收取荒原',
+    '每日心相（意志解析）',
+    '常规作战',
+    '自动深眠',
+    '自动醒梦',
+    '银行购物',
+    '领取奖励',
+    '使用兑换码',
+  ],
+}
+
+// 一键添加状态
+const addingFromPreset = ref(false)
+
+// 匹配预设任务（根据 availableTasks 做名称匹配）
+interface MatchedTaskItem {
+  name: string
+  matched: boolean
+}
+
+const matchedTasks = computed<MatchedTaskItem[]>(() => {
+  return dailyPreset.taskNames.map(name => ({
+    name,
+    matched: availableTasks.value.some(t => t.name === name),
+  }))
+})
+
+const matchedCount = computed(() => matchedTasks.value.filter(t => t.matched).length)
 
 const buildDefaultOptions = (taskDef: any): M9ATaskOption[] => {
   const options: M9ATaskOption[] = []
@@ -212,6 +290,32 @@ const handleAddTask = ({ key }: { key: string }) => {
     selectedTaskIndex.value = newQueue.length - 1
   }
   addTaskDropdownVisible.value = false
+}
+
+// 从预设模板一键添加任务
+const addFromPreset = () => {
+  const validTasks = matchedTasks.value.filter(t => t.matched)
+  if (validTasks.length === 0) return
+
+  addingFromPreset.value = true
+  let newQueue = [...localTaskQueue.value]
+
+  try {
+    for (const task of validTasks) {
+      const taskDef = taskDefinitions.value[task.name]
+      if (taskDef) {
+        newQueue.push({
+          name: task.name,
+          options: buildDefaultOptions(taskDef),
+        })
+      }
+    }
+
+    emit('update:taskQueue', newQueue)
+    message.success(`成功添加 ${validTasks.length} 个任务`)
+  } finally {
+    addingFromPreset.value = false
+  }
 }
 
 const selectTask = (index: number) => {
@@ -464,5 +568,184 @@ onMounted(() => {
 
 .drag {
   opacity: 0.8;
+}
+
+/* 预设模板区域 */
+.preset-section {
+  height: 100%;
+}
+
+.preset-card {
+  height: 100%;
+  border-radius: 10px;
+  overflow: hidden;
+  animation: presetFadeIn 0.4s ease-out;
+}
+
+.preset-card-inner {
+  background: linear-gradient(135deg, rgba(24, 144, 255, 0.04) 0%, rgba(24, 144, 255, 0.01) 100%);
+  border: 1px solid rgba(24, 144, 255, 0.15);
+  border-radius: 10px;
+  padding: 18px 20px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  transition: all 0.3s ease;
+}
+
+.preset-card-inner:hover {
+  border-color: var(--ant-color-primary);
+  box-shadow: 0 4px 16px rgba(24, 144, 255, 0.1);
+}
+
+.preset-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.preset-icon-wrap {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #1677ff 0%, #4096ff 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  box-shadow: 0 2px 8px rgba(22, 119, 255, 0.25);
+}
+
+.preset-icon {
+  font-size: 20px;
+  line-height: 1;
+}
+
+.preset-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.preset-name {
+  margin: 0 0 3px 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--ant-color-text);
+  letter-spacing: -0.2px;
+}
+
+.preset-desc {
+  margin: 0;
+  font-size: 12px;
+  color: var(--ant-color-text-secondary);
+  line-height: 1.5;
+}
+
+.preset-badge {
+  flex-shrink: 0;
+}
+
+.preset-tasks-preview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 16px;
+  padding: 10px 12px;
+  background: var(--ant-color-bg-container);
+  border-radius: 8px;
+  border: 1px solid var(--ant-color-border-secondary);
+}
+
+.task-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 10px 3px 7px;
+  border-radius: 20px;
+  font-size: 13px;
+  background: var(--ant-color-fill-quaternary);
+  color: var(--ant-color-text);
+  transition: all 0.2s ease;
+}
+
+.task-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ant-color-success);
+  flex-shrink: 0;
+  box-shadow: 0 0 4px rgba(82, 196, 26, 0.35);
+}
+
+.task-dot-miss {
+  background: var(--ant-color-text-disabled);
+  box-shadow: none;
+}
+
+.task-name {
+  white-space: nowrap;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.task-name-miss {
+  text-decoration: line-through;
+  opacity: 0.45;
+}
+
+.task-check {
+  font-size: 11px;
+  color: var(--ant-color-success);
+  flex-shrink: 0;
+}
+
+.task-check-miss {
+  color: var(--ant-color-text-disabled);
+}
+
+.preset-actions {
+  margin-top: auto;
+}
+
+.preset-actions :deep(.ant-btn-primary) {
+  height: 40px;
+  font-size: 14px;
+  font-weight: 600;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #1677ff 0%, #4096ff 100%);
+  border: none;
+  box-shadow: 0 2px 8px rgba(22, 119, 255, 0.2);
+  transition: all 0.25s ease;
+}
+
+.preset-actions :deep(.ant-btn-primary:hover:not(:disabled)) {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(22, 119, 255, 0.3);
+}
+
+.preset-actions :deep(.ant-btn-primary:active:not(:disabled)) {
+  transform: translateY(0);
+  box-shadow: 0 2px 6px rgba(22, 119, 255, 0.2);
+}
+
+.preset-hint {
+  margin: 8px 0 0 0;
+  text-align: center;
+  font-size: 12px;
+  color: var(--ant-color-text-tertiary);
+  line-height: 1.4;
+}
+
+@keyframes presetFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 </style>

--- a/frontend/src/views/M9AUserEdit/TaskQueueSection.vue
+++ b/frontend/src/views/M9AUserEdit/TaskQueueSection.vue
@@ -9,7 +9,7 @@
         <div class="column-header">
           <span>任务队列</span>
           <a-dropdown v-model:visible="addTaskDropdownVisible" trigger="click">
-            <a-button type="primary" size="small" :loading="loading">
+            <a-button type="primary" size="middle" :loading="loading">
               <template #icon><PlusOutlined /></template>
               添加任务 ({{ availableTasks.length }})
             </a-button>
@@ -45,7 +45,7 @@
                   <div class="task-actions">
                     <a-button
                       type="text"
-                      size="small"
+                      size="middle"
                       :disabled="index === 0"
                       @click.stop="moveTaskUp(index)"
                     >
@@ -53,19 +53,11 @@
                     </a-button>
                     <a-button
                       type="text"
-                      size="small"
+                      size="middle"
                       :disabled="index === localTaskQueue.length - 1"
                       @click.stop="moveTaskDown(index)"
                     >
                       <DownOutlined />
-                    </a-button>
-                    <a-button
-                      type="text"
-                      size="small"
-                      danger
-                      @click.stop="deleteTask(index)"
-                    >
-                      <DeleteOutlined />
                     </a-button>
                   </div>
                 </div>
@@ -91,15 +83,12 @@
             @update="handleOptionUpdate"
           />
           
-          <a-button
-            type="primary"
-            danger
-            block
-            style="margin-top: 24px"
-            @click="deleteSelectedTask"
-          >
-            删除此任务
-          </a-button>
+          <a-popconfirm title="确定要删除这个任务吗？" ok-text="确定" cancel-text="取消" @confirm="deleteSelectedTask">
+            <a-button danger block style="margin-top: 24px; height: 40px; font-size: 14px;">
+              <template #icon><DeleteOutlined /></template>
+              删除此任务
+            </a-button>
+          </a-popconfirm>
         </div>
         
         <div class="no-selection" v-else>
@@ -372,18 +361,23 @@ onMounted(() => {
 .task-queue-list {
   height: 100%;
   border: 1px solid var(--ant-color-border);
-  border-radius: 8px;
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  overflow: hidden;
 }
 
 .draggable-task-item {
-  padding: 12px 16px;
+  padding: 16px 20px;
   border-bottom: 1px solid var(--ant-color-border);
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: all 0.25s ease;
+  border-left: 3px solid transparent;
 }
 
-.draggable-task-item:hover {
+/* 未选中状态的 hover 效果 */
+.draggable-task-item:not(.selected-item):hover {
   background-color: var(--ant-color-primary-bg-hover);
+  border-left-color: var(--ant-color-primary);
 }
 
 .draggable-task-item:last-child {
@@ -399,29 +393,55 @@ onMounted(() => {
 
 .task-name {
   flex: 1;
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--ant-color-text);
 }
 
 .task-actions {
   display: flex;
-  gap: 4px;
+  gap: 8px;
 }
 
+.task-actions :deep(.ant-btn) {
+  transition: all 0.2s ease;
+  border-radius: 6px;
+}
+
+.task-actions :deep(.ant-btn:hover) {
+  background-color: var(--ant-color-primary-bg-hover);
+}
+
+/* 选中状态的样式（始终显示，使用 !important 确保不被 hover 覆盖）*/
 .selected-item {
-  background-color: var(--ant-color-primary-bg);
+  background-color: var(--ant-color-primary-bg) !important;
+  border-left-color: var(--ant-color-primary) !important;
+}
+
+/* 选中 + hover 时：保持高亮不变 */
+.selected-item:hover {
+  background-color: var(--ant-color-primary-bg) !important;
+  border-left-color: var(--ant-color-primary-hover, #1890ff) !important;
 }
 
 .task-config {
-  padding: 16px;
+  padding: 24px;
   border: 1px solid var(--ant-color-border);
-  border-radius: 8px;
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  background: var(--ant-color-bg-container);
 }
 
 .selected-task-name {
-  font-size: 18px;
-  font-weight: 600;
-  margin-bottom: 16px;
-  padding-bottom: 12px;
-  border-bottom: 1px solid var(--ant-color-border);
+  font-size: 20px;
+  font-weight: 700;
+  margin-bottom: 20px;
+  padding-bottom: 16px;
+  border-bottom: 2px solid var(--ant-color-border-secondary);
+  color: var(--ant-color-text);
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .no-selection {


### PR DESCRIPTION
## 概述

对 M9A 用户编辑页面进行全链路体验增强，涵盖后端 Schema 扩展、脚本自动化处理、前端 UI 整体重构，以及任务队列预设模板一键填充。

## 改动范围

| 文件 | 操作 |
|------|------|
| `frontend/src/views/M9AUserEdit/TaskQueueSection.vue` | 修改 |
| `frontend/src/views/M9AUserEdit/BasicInfoSection.vue` | 修改 |
| `frontend/src/views/M9AUserEdit/NotifyConfigSection.vue` | 修改 |
| `frontend/src/views/EditView/User/M9AUserEdit.vue` | 修改 |
| `frontend/src/views/EditView/Script/M9AScriptEdit.vue` | 修改 |
| `frontend/src/components/ScriptTable.vue` | 修改 |
| `frontend/src/composables/useScriptApi.ts` | 修改 |
| `app/task/M9A/AutoProxy.py` | 修改 |
| `app/models/schema.py` | 修改 |

## Commit 详情

### 1. `808fce5` feat(M9A): 适配服务器选择

- 后端 Schema 扩展，新增 M9A 服务器选择字段支持
- 前端 M9A 脚本/用户编辑页添加服务器下拉选择

### 2. `2b47954` feat(M9A)：新增账号切换适配与自动化排序基础任务

- 禁止手动添加启动/关闭/切换账号任务，旧数据加载时自动清理
- 队列自动补齐首尾（启动游戏 / 关闭游戏）
- 新增 `Info.Account` 字段，官服填写后自动插入切换账号任务
- 基本信息布局调整：第二行左服务器右账号信息，第三行剩余天数

### 3. `21dd9ae` feat(M9A)：M9A 用户页面前端整体优化

- 新增 M9A 配置指南底部常驻提示栏（含 37 icon + 官方文档链接）
- 优化任务队列交互：增大操作按钮尺寸，删除重复删除入口
- 左侧任务列表增加左边框指示器，提升操作区域视觉反馈
- 优化任务列表 & 配置面板的间距、字号、圆角和阴影层次
- 基本信息 & 通知配置区域统一增大间距至 40px
- 输入框聚焦色改为代表色（cyan #13c2c2）
- M9A 脚本列表支持显示服务器标签
- M9A 用户列表支持显示后端 Tag（如「日常：未代理」「剩余天数：无期限」）

### 4. `4e4c5ae` feat(M9A): 任务队列空状态添加 Daily 预设模板一键填充

队列为空时展示"日常-长草"预设模板卡片：

> 无活动或换完商店时使用，进行常规刷取

包含 8 个任务（已跳过启动游戏/关闭游戏）：
收取荒原 → 每日心相 → 常规作战 → 自动深眠 → 自动醒梦 → 银行购物 → 领取奖励 → 使用兑换码

交互逻辑：
- 队列为空 → 显示模板卡片 + 一键添加按钮
- 有任务时 → 正常拖拽列表，模板隐藏
- 根据 availableTasks 自动匹配，未匹配项置灰+删除线展示并自动跳过
- 渐变蓝底按钮 + hover 上浮动效 + fadeIn 入场动画