### PR TITLE
feat(okww): 前端表单化配置编辑器，替代启动ok-ww GUI配置

### DIFF
--- a/app/api/scripts.py
+++ b/app/api/scripts.py
@@ -22,6 +22,8 @@
 
 
 import uuid
+from pathlib import Path
+
 from fastapi import APIRouter, Body
 
 from app.core import Config
@@ -537,4 +539,241 @@ async def get_m9a_available_tasks(script_id: str):
             "status": "error",
             "message": f"{type(e).__name__}: {str(e)}",
             "data": []
+        }
+
+
+@router.post(
+    "/okww/configs/list",
+    tags=["OKWW"],
+    summary="获取 OK-WW 配置文件列表及 schema",
+    status_code=200,
+)
+async def get_okww_configs_list(script_id: str):
+    """
+    获取 OK-WW 配置文件列表及 schema 定义。
+    读写 per-user 配置目录（data/{script_id}/Default/ConfigFile/），
+    若为空则自动从 ok-ww configs 目录初始化默认配置。
+
+    Args:
+        script_id: OK-WW 脚本 ID
+
+    Returns:
+        dict: 包含配置文件列表和 schema 的响应
+    """
+    try:
+        import shutil
+        from app.task.Okww.config_schema import get_all_config_info, CONFIG_SCHEMA_MAP, OPTION_LABELS
+
+        script_config = Config.ScriptConfig[uuid.UUID(script_id)]
+
+        # per-user 配置目录（始终使用 Default，因为配置编辑器是脚本级的）
+        mas_config_dir = Path.cwd() / f"data/{script_id}/Default/ConfigFile"
+
+        # ok-ww 源配置目录（用于自动初始化）
+        raw_config_path = script_config.get("Script", "ConfigPath")
+        raw_root_path = script_config.get("Info", "RootPath")
+        okww_configs_dir = Path(raw_config_path) if raw_config_path else None
+        if not okww_configs_dir or not okww_configs_dir.exists():
+            if raw_root_path:
+                okww_configs_dir = Path(raw_root_path) / "data" / "apps" / "ok-ww" / "working" / "configs"
+
+        # 自动初始化：per-user 目录为空时从 ok-ww configs 复制默认配置
+        need_init = not mas_config_dir.exists() or not any(mas_config_dir.iterdir())
+        if need_init and okww_configs_dir and okww_configs_dir.is_dir():
+            mas_config_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(okww_configs_dir, mas_config_dir, dirs_exist_ok=True)
+
+        configs_info = get_all_config_info()
+
+        # 从 per-user 目录读取配置
+        configs_data = {}
+        if mas_config_dir.is_dir():
+            for info in configs_info:
+                filepath = mas_config_dir / info["filename"]
+                if filepath.exists():
+                    try:
+                        import json
+                        with open(filepath, "r", encoding="utf-8") as f:
+                            configs_data[info["filename"]] = json.load(f)
+                    except Exception:
+                        configs_data[info["filename"]] = {}
+
+        # 构建完整 schema（包含当前值）
+        result = []
+        for info in configs_info:
+            filename = info["filename"]
+            schema = CONFIG_SCHEMA_MAP.get(filename, {})
+            current_data = configs_data.get(filename, {})
+
+            fields = []
+            for field_name, field_def in schema.items():
+                fields.append({
+                    "name": field_name,
+                    "type": field_def["type"],
+                    "label": field_def.get("label", field_name),
+                    "description": field_def.get("description", ""),
+                    "value": current_data.get(field_name),
+                    "options": field_def.get("options"),
+                    "min": field_def.get("min"),
+                    "max": field_def.get("max"),
+                    "step": field_def.get("step"),
+                })
+
+            # 也包含 schema 中未定义但配置文件中存在的字段
+            for field_name, field_value in current_data.items():
+                if not any(f["name"] == field_name for f in fields):
+                    # 推断类型
+                    if isinstance(field_value, bool):
+                        field_type = "bool"
+                    elif isinstance(field_value, int):
+                        field_type = "int"
+                    elif isinstance(field_value, float):
+                        field_type = "float"
+                    elif isinstance(field_value, list):
+                        field_type = "list"
+                    else:
+                        field_type = "string"
+                    fields.append({
+                        "name": field_name,
+                        "type": field_type,
+                        "label": field_name,
+                        "description": "",
+                        "value": field_value,
+                        "options": None,
+                        "min": None,
+                        "max": None,
+                        "step": None,
+                    })
+
+            result.append({
+                **info,
+                "fields": fields,
+                "currentData": current_data,
+            })
+
+        return {
+            "code": 200,
+            "status": "success",
+            "message": f"共 {len(result)} 个配置文件",
+            "data": result,
+            "optionLabels": OPTION_LABELS,
+            "configPath": str(mas_config_dir) if mas_config_dir else None,
+        }
+    except Exception as e:
+        return {
+            "code": 500,
+            "status": "error",
+            "message": f"{type(e).__name__}: {str(e)}",
+            "data": [],
+        }
+
+
+@router.post(
+    "/okww/configs/update",
+    tags=["OKWW"],
+    summary="更新 OK-WW 配置文件",
+    status_code=200,
+)
+async def update_okww_config(
+    script_id: str = Body(...),
+    filename: str = Body(...),
+    data: dict = Body(...),
+):
+    """
+    更新 OK-WW 配置文件
+
+    Args:
+        script_id: OK-WW 脚本 ID
+        filename: 配置文件名（如 DailyTask.json）
+        data: 要更新的配置数据
+
+    Returns:
+        dict: 操作结果
+    """
+    try:
+        import json
+
+        # 写入 per-user 配置目录
+        mas_config_dir = Path.cwd() / f"data/{script_id}/Default/ConfigFile"
+        mas_config_dir.mkdir(parents=True, exist_ok=True)
+
+        filepath = mas_config_dir / filename
+
+        # 读取现有配置
+        existing_data = {}
+        if filepath.exists():
+            with open(filepath, "r", encoding="utf-8") as f:
+                existing_data = json.load(f)
+
+        # 合并更新
+        existing_data.update(data)
+
+        # 写入 per-user 目录
+        with open(filepath, "w", encoding="utf-8") as f:
+            json.dump(existing_data, f, ensure_ascii=False, indent=4)
+
+        return {
+            "code": 200,
+            "status": "success",
+            "message": f"配置文件 {filename} 已更新",
+            "data": existing_data,
+        }
+    except Exception as e:
+        return {
+            "code": 500,
+            "status": "error",
+            "message": f"{type(e).__name__}: {str(e)}",
+        }
+
+
+@router.post(
+    "/okww/configs/batch-update",
+    tags=["OKWW"],
+    summary="批量更新 OK-WW 配置文件",
+    status_code=200,
+)
+async def batch_update_okww_configs(
+    script_id: str = Body(...),
+    configs: dict = Body(...),
+):
+    """
+    批量更新 OK-WW 配置文件
+
+    Args:
+        script_id: OK-WW 脚本 ID
+        configs: { filename: data } 格式的配置数据
+
+    Returns:
+        dict: 操作结果
+    """
+    try:
+        import json
+
+        # 写入 per-user 配置目录
+        mas_config_dir = Path.cwd() / f"data/{script_id}/Default/ConfigFile"
+        mas_config_dir.mkdir(parents=True, exist_ok=True)
+
+        updated_files = []
+        for filename, data in configs.items():
+            filepath = mas_config_dir / filename
+            existing_data = {}
+            if filepath.exists():
+                with open(filepath, "r", encoding="utf-8") as f:
+                    existing_data = json.load(f)
+            existing_data.update(data)
+            with open(filepath, "w", encoding="utf-8") as f:
+                json.dump(existing_data, f, ensure_ascii=False, indent=4)
+            updated_files.append(filename)
+
+        return {
+            "code": 200,
+            "status": "success",
+            "message": f"已更新 {len(updated_files)} 个配置文件",
+            "data": updated_files,
+        }
+    except Exception as e:
+        return {
+            "code": 500,
+            "status": "error",
+            "message": f"{type(e).__name__}: {str(e)}",
         }

--- a/app/task/Okww/AutoProxy.py
+++ b/app/task/Okww/AutoProxy.py
@@ -107,15 +107,6 @@ class AutoProxyTask(TaskExecuteBase):
             self.cur_user_item.status = "跳过"
             return "用户剩余天数为 0, 跳过该用户"
 
-        mode = str(self.cur_user_config.get("Info", "Mode") or "简洁")
-        config_owner = "Default" if mode == "简洁" else str(self.cur_user_uid)
-        mas_config_dir = Path.cwd() / f"data/{self.script_info.script_id}/{config_owner}/ConfigFile"
-        if not (mas_config_dir.is_dir() and any(mas_config_dir.iterdir())):
-            self.cur_user_item.status = "异常"
-            if mode == "简洁":
-                return "未找到共享的 OK-WW 配置文件，请先在脚本页完成「配置 ok-ww」步骤"
-            return "未找到用户的 OK-WW 配置文件，请先在用户配置页完成「配置 ok-ww」步骤"
-
         if (
             self.script_config.get("Game", "Enabled")
             and self.script_config.get("Game", "Type") == "Client"

--- a/app/task/Okww/config_schema.py
+++ b/app/task/Okww/config_schema.py
@@ -1,0 +1,656 @@
+#   AUTO-MAS: A Multi-Script, Multi-Config Management and Automation Software
+#   Copyright © 2025-2026 AUTO-MAS Team
+#
+#   This file is part of AUTO-MAS.
+#
+#   AUTO-MAS is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of
+#   the License, or (at your option) any later version.
+#
+#   AUTO-MAS is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+#   the GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with AUTO-MAS. If not, see <https://www.gnu.org/licenses/>.
+
+"""
+OK-WW 配置文件 Schema 定义
+
+定义 configs/ 目录下各 JSON 配置文件的字段类型、选项和默认值，
+用于前端表单化渲染。
+"""
+
+from __future__ import annotations
+from typing import Any, Literal
+
+# 字段类型枚举
+# bool    — 开关 (a-switch)
+# int     — 整数 (a-input-number)
+# float   — 浮点数 (a-input-number, step=0.1)
+# string  — 文本 (a-input)
+# select  — 下拉选择 (a-select)
+# list    — 列表 (a-select mode="multiple")
+# hotkey  — 快捷键 (a-input，展示用)
+
+FieldSchema = dict[str, Any]
+
+
+def _field(
+    type: str,
+    label: str = "",
+    description: str = "",
+    **kwargs: Any,
+) -> FieldSchema:
+    """构建字段 schema"""
+    schema: FieldSchema = {"type": type, "label": label, "description": description}
+    schema.update(kwargs)
+    return schema
+
+
+# 选项值的中文翻译映射（key=英文原值, value=中文显示）
+OPTION_LABELS: dict[str, str] = {
+    # 通用
+    "Yes": "是",
+    "No": "否",
+    "Auto": "自动",
+    # DailyTask - Which to Farm
+    "Forgery Challenge": "凝素领域",
+    "Tacet Suppression": "无音区",
+    "Simulation": "模拟领域",
+    "Nightmare Nest": "梦魇巢穴",
+    # DailyTask / SimulationTask - Material Selection
+    "Weapon EXP": "武器经验",
+    "Shell Credit": "贝币",
+    "Character EXP": "角色经验",
+    # FarmEchoTask - Echo Pickup Method
+    "Yolo": "自动拾取",
+    "Click": "点击拾取",
+    # FarmEchoTask - Boss
+    "Other": "其他",
+    # NightmareNestTask - Which to Farm
+    "Nightmare Purification": "梦魇祓除",
+    "Tacet Discord Nest": "残像聚落",
+    # Basic Options - Blur Algorithm
+    "Inpaint": "修复",
+    "Gaussian": "高斯",
+}
+
+
+# ─── 任务配置 Schema ──────────────────────────────────────────────────────────
+
+DAILY_TASK_SCHEMA: dict[str, FieldSchema] = {
+    "Which to Farm": _field(
+        "select",
+        label="刷取目标",
+        description="选择要刷取的副本类型",
+        options=[
+            "Forgery Challenge",
+            "Tacet Suppression",
+            "Simulation",
+            "Nightmare Nest",
+        ],
+    ),
+    "Which Tacet Suppression to Farm": _field(
+        "int",
+        label="无音区序号",
+        description="选择要刷取的无音区（从 1 开始）",
+        min=1,
+        max=20,
+    ),
+    "Which Forgery Challenge to Farm": _field(
+        "int",
+        label="凝素领域序号",
+        description="选择要刷取的凝素领域（从 1 开始）",
+        min=1,
+        max=20,
+    ),
+    "Material Selection": _field(
+        "select",
+        label="材料选择",
+        description="选择要刷取的材料",
+        options=[
+            "Weapon EXP",
+            "Shell Credit",
+            "Character EXP",
+        ],
+    ),
+    "Auto Farm all Nightmare Nest": _field(
+        "bool",
+        label="自动刷取所有梦魇巢穴",
+        description="开启后将自动刷取所有梦魇巢穴",
+    ),
+    "Farm Nightmare Nest for Daily Echo": _field(
+        "bool",
+        label="梦魇巢穴刷取声骸",
+        description="开启后在梦魇巢穴中刷取声骸",
+    ),
+    "Exit After Task": _field(
+        "bool",
+        label="任务完成后退出",
+        description="任务完成后是否退出游戏",
+    ),
+}
+
+MULTI_ACCOUNT_DAILY_TASK_SCHEMA: dict[str, FieldSchema] = {
+    "Exit After Task": _field(
+        "bool",
+        label="任务完成后退出",
+        description="任务完成后是否退出游戏",
+    ),
+}
+
+FARM_ECHO_TASK_SCHEMA: dict[str, FieldSchema] = {
+    "Teleport to Boss": _field(
+        "select",
+        label="传送到Boss",
+        description="选择是否传送到Boss",
+        options=["No", "Yes"],
+    ),
+    "Boss Level": _field(
+        "select",
+        label="Boss等级",
+        description="选择Boss等级",
+        options=["60", "70", "80", "90"],
+    ),
+    "Boss": _field(
+        "string",
+        label="Boss名称",
+        description="指定要刷的Boss名称，填 Other 使用默认",
+    ),
+    "Repeat Farm Count": _field(
+        "int",
+        label="重复刷取次数",
+        description="重复刷取的次数上限",
+        min=1,
+        max=99999,
+    ),
+    "Combat Wait Time": _field(
+        "int",
+        label="战斗等待时间（秒）",
+        description="战斗结束后等待的时间",
+        min=0,
+        max=60,
+    ),
+    "Echo Pickup Method": _field(
+        "select",
+        label="声骸拾取方式",
+        description="选择声骸拾取方式",
+        options=["Yolo", "Click"],
+    ),
+    "Use Liberation": _field(
+        "bool",
+        label="使用解放技能",
+        description="是否在战斗中使用解放技能",
+    ),
+    "Switch to Healer after Combat": _field(
+        "bool",
+        label="战斗后切换治疗角色",
+        description="战斗结束后是否切换到治疗角色",
+    ),
+    "Which Weekly Boss to Teleport": _field(
+        "int",
+        label="周本Boss序号",
+        description="选择要传送的周本Boss（从 1 开始）",
+        min=1,
+        max=10,
+    ),
+    "Which Boss Challenge to Teleport": _field(
+        "int",
+        label="Boss挑战序号",
+        description="选择要传送的Boss挑战（从 1 开始）",
+        min=1,
+        max=10,
+    ),
+    "Exit After Task": _field(
+        "bool",
+        label="任务完成后退出",
+        description="任务完成后是否退出游戏",
+    ),
+}
+
+AUTO_ROGUE_TASK_SCHEMA: dict[str, FieldSchema] = {
+    "_enabled": _field(
+        "bool",
+        label="启用",
+        description="是否启用半自动肉鸽任务",
+    ),
+    "Stop When Treasure Found": _field(
+        "bool",
+        label="发现宝藏时停止",
+        description="发现宝藏后是否停止任务",
+    ),
+}
+
+FORGERY_TASK_SCHEMA: dict[str, FieldSchema] = {
+    "Which Forgery Challenge to Farm": _field(
+        "int",
+        label="凝素领域序号",
+        description="选择要刷取的凝素领域（从 1 开始）",
+        min=1,
+        max=20,
+    ),
+}
+
+NIGHTMARE_NEST_TASK_SCHEMA: dict[str, FieldSchema] = {
+    "_enabled": _field(
+        "bool",
+        label="启用",
+        description="是否启用梦魇巢穴任务",
+    ),
+    "Which to Farm": _field(
+        "list",
+        label="刷取目标",
+        description="选择要刷取的梦魇巢穴类型",
+        options=[
+            "Nightmare Purification",
+            "Tacet Discord Nest",
+        ],
+    ),
+}
+
+SIMULATION_TASK_SCHEMA: dict[str, FieldSchema] = {
+    "Material Selection": _field(
+        "select",
+        label="材料选择",
+        description="选择要刷取的材料",
+        options=[
+            "Shell Credit",
+            "Character EXP",
+            "Weapon EXP",
+        ],
+    ),
+}
+
+TACET_TASK_SCHEMA: dict[str, FieldSchema] = {
+    "Which Tacet Suppression to Farm": _field(
+        "int",
+        label="无音区序号",
+        description="选择要刷取的无音区（从 1 开始）",
+        min=1,
+        max=20,
+    ),
+}
+
+# ─── 任务子配置 Schema ──────────────────────────────────────────────────────
+
+ENHANCE_ECHO_TASK_SCHEMA: dict[str, FieldSchema] = {
+    "必须有双爆": _field(
+        "bool",
+        label="必须有双爆",
+        description="声骸必须同时有暴击率和暴击伤害",
+    ),
+    "双爆出现之前必须全有效词条": _field(
+        "bool",
+        label="双爆前全有效词条",
+        description="在双爆出现之前必须全部为有效词条",
+    ),
+    "双爆总计>=": _field(
+        "float",
+        label="双爆总计≥",
+        description="双爆总计最低要求",
+        min=0,
+        max=100,
+        step=0.1,
+    ),
+    "首条双爆>=": _field(
+        "float",
+        label="首条双爆≥",
+        description="第一条双爆的最低要求",
+        min=0,
+        max=100,
+        step=0.1,
+    ),
+    "有效词条>=": _field(
+        "int",
+        label="有效词条≥",
+        description="有效词条的最低数量",
+        min=0,
+        max=10,
+    ),
+    "第一条必须为有效词条": _field(
+        "bool",
+        label="首条必须有效",
+        description="第一条词条必须为有效词条",
+    ),
+    "有效词条": _field(
+        "list",
+        label="有效词条列表",
+        description="选择视为有效的词条",
+        options=[
+            "暴击伤害",
+            "暴击",
+            "攻击百分比",
+            "共鸣效率",
+            "共鸣解放伤害加成",
+            "普攻伤害加成",
+            "重击伤害加成",
+            "共鸣技能伤害加成",
+            "攻击",
+            "生命百分比",
+            "防御百分比",
+        ],
+    ),
+    "Pause after Success": _field(
+        "bool",
+        label="成功后暂停",
+        description="声骸强化成功后暂停任务",
+    ),
+}
+
+AUTO_COMBAT_TASK_SCHEMA: dict[str, FieldSchema] = {
+    "_enabled": _field(
+        "bool",
+        label="启用",
+        description="是否启用自动战斗",
+    ),
+    "Auto Target": _field(
+        "bool",
+        label="自动锁定目标",
+        description="是否自动锁定敌人",
+    ),
+    "Use Liberation": _field(
+        "bool",
+        label="使用解放技能",
+        description="是否使用解放技能",
+    ),
+    "Check Levitator": _field(
+        "bool",
+        label="检测悬浮道具",
+        description="是否检测悬浮道具",
+    ),
+}
+
+AUTO_PICK_TASK_SCHEMA: dict[str, FieldSchema] = {
+    "_enabled": _field(
+        "bool",
+        label="启用",
+        description="是否启用自动拾取",
+    ),
+    "Pick Up White List": _field(
+        "list",
+        label="拾取白名单",
+        description="自动拾取的物品关键词",
+        options=[
+            "吸收",
+            "Absorb",
+            "拾取",
+            "Pick Up",
+        ],
+    ),
+    "Pick Up Black List": _field(
+        "list",
+        label="拾取黑名单",
+        description="不自动拾取的物品关键词",
+        options=[
+            "开始合成",
+            "领取奖励",
+            "Claim",
+            "合成台",
+        ],
+    ),
+}
+
+AUTO_DIALOG_TASK_SCHEMA: dict[str, FieldSchema] = {
+    "_enabled": _field(
+        "bool",
+        label="启用",
+        description="是否启用自动对话",
+    ),
+}
+
+CHANGE_ECHO_TASK_SCHEMA: dict[str, FieldSchema] = {
+    "Use OCR": _field(
+        "bool",
+        label="使用OCR",
+        description="是否使用OCR识别",
+    ),
+}
+
+# ─── 全局配置 Schema ────────────────────────────────────────────────────────
+
+GAME_HOTKEY_SCHEMA: dict[str, FieldSchema] = {
+    "Echo Key": _field(
+        "hotkey",
+        label="声骸技能键",
+        description="声骸技能快捷键",
+    ),
+    "Liberation Key": _field(
+        "hotkey",
+        label="解放技能键",
+        description="解放技能快捷键",
+    ),
+    "Resonance Key": _field(
+        "hotkey",
+        label="共鸣技能键",
+        description="共鸣技能快捷键",
+    ),
+    "Tool Key": _field(
+        "hotkey",
+        label="工具键",
+        description="工具快捷键",
+    ),
+    "Jump Key": _field(
+        "hotkey",
+        label="跳跃键",
+        description="跳跃快捷键",
+    ),
+    "Dodge Key": _field(
+        "hotkey",
+        label="闪避键",
+        description="闪避快捷键",
+    ),
+    "Wheel Key": _field(
+        "hotkey",
+        label="轮盘键",
+        description="轮盘快捷键",
+    ),
+}
+
+CHARACTER_CONFIG_SCHEMA: dict[str, FieldSchema] = {
+    "Iuno C6": _field(
+        "bool",
+        label="伊努诺 C6",
+        description="是否启用伊努诺 C6 配置",
+    ),
+    "Chisa DPS": _field(
+        "bool",
+        label="千纱 DPS",
+        description="是否启用千纱 DPS 配置",
+    ),
+}
+
+MONTHLY_CARD_CONFIG_SCHEMA: dict[str, FieldSchema] = {
+    "Check Monthly Card": _field(
+        "bool",
+        label="检查月卡",
+        description="是否检查月卡弹窗",
+    ),
+    "Monthly Card Time": _field(
+        "int",
+        label="月卡弹出时间",
+        description="电脑本地时间，月卡弹出的小时（1-24）",
+        min=1,
+        max=24,
+    ),
+}
+
+BASIC_OPTIONS_SCHEMA: dict[str, FieldSchema] = {
+    "Auto Start Game When App Starts": _field(
+        "bool",
+        label="启动时自动开始游戏",
+        description="应用启动时是否自动开始游戏",
+    ),
+    "Minimize Window to System Tray when Closing": _field(
+        "bool",
+        label="关闭时最小化到托盘",
+        description="关闭窗口时是否最小化到系统托盘",
+    ),
+    "Mute Game while in Background": _field(
+        "bool",
+        label="后台时静音游戏",
+        description="游戏在后台时是否静音",
+    ),
+    "Auto Resize Game Window": _field(
+        "bool",
+        label="自动调整游戏窗口",
+        description="是否自动调整游戏窗口大小",
+    ),
+    "Exit App when Game Exits": _field(
+        "bool",
+        label="游戏退出时关闭应用",
+        description="游戏退出后是否关闭应用",
+    ),
+    "Use DirectML": _field(
+        "select",
+        label="使用 DirectML",
+        description="DirectML 加速选项",
+        options=["Auto", "Yes", "No"],
+    ),
+    "Trigger Interval": _field(
+        "int",
+        label="触发间隔（秒）",
+        description="任务触发间隔时间",
+        min=1,
+        max=60,
+    ),
+    "Start/Stop": _field(
+        "hotkey",
+        label="启动/停止快捷键",
+        description="启动或停止任务的快捷键",
+    ),
+    "Kill Launcher after Start": _field(
+        "bool",
+        label="启动后关闭启动器",
+        description="游戏启动后是否关闭启动器",
+    ),
+    "Launch with DX11": _field(
+        "bool",
+        label="使用 DX11 启动",
+        description="是否使用 DirectX 11 启动游戏",
+    ),
+    "Enable Blur": _field(
+        "bool",
+        label="启用模糊",
+        description="是否启用界面模糊效果",
+    ),
+    "Blur Algorithm": _field(
+        "select",
+        label="模糊算法",
+        description="选择模糊算法",
+        options=["Inpaint", "Gaussian"],
+    ),
+    "Blur Interval": _field(
+        "int",
+        label="模糊间隔",
+        description="模糊处理间隔",
+        min=1,
+        max=10,
+    ),
+}
+
+# ─── 配置文件注册表 ─────────────────────────────────────────────────────────
+
+# 分组定义：前端按分组展示
+CONFIG_GROUPS = {
+    "任务配置": [
+        "DailyTask.json",
+        "MultiAccountDailyTask.json",
+        "FarmEchoTask.json",
+        "AutoRogueTask.json",
+        "ForgeryTask.json",
+        "NightmareNestTask.json",
+        "SimulationTask.json",
+        "TacetTask.json",
+    ],
+    "任务子配置": [
+        "EnhanceEchoTask.json",
+        "AutoCombatTask.json",
+        "AutoPickTask.json",
+        "AutoDialogTask.json",
+        "ChangeEchoTask.json",
+    ],
+    "全局配置": [
+        "Game Hotkey.json",
+        "Character Config.json",
+        "Monthly Card Config.json",
+        "Basic Options.json",
+    ],
+}
+
+# 文件名 -> 显示名
+CONFIG_DISPLAY_NAMES: dict[str, str] = {
+    "DailyTask.json": "日常任务",
+    "MultiAccountDailyTask.json": "多账号日常",
+    "FarmEchoTask.json": "刷声骸",
+    "AutoRogueTask.json": "半自动肉鸽",
+    "ForgeryTask.json": "凝素领域",
+    "NightmareNestTask.json": "梦魇巢穴",
+    "SimulationTask.json": "模拟领域",
+    "TacetTask.json": "无音区",
+    "EnhanceEchoTask.json": "声骸强化",
+    "AutoCombatTask.json": "自动战斗",
+    "AutoPickTask.json": "自动拾取",
+    "AutoDialogTask.json": "自动对话",
+    "ChangeEchoTask.json": "切换声骸",
+    "Game Hotkey.json": "游戏热键",
+    "Character Config.json": "角色配置",
+    "Monthly Card Config.json": "月卡配置",
+    "Basic Options.json": "基础选项",
+}
+
+# 文件名 -> 任务序号（用于与 TaskIndex 关联）
+TASK_INDEX_MAP: dict[str, int] = {
+    "DailyTask.json": 1,
+    "MultiAccountDailyTask.json": 2,
+    "FarmEchoTask.json": 3,
+    "AutoRogueTask.json": 4,
+    "ForgeryTask.json": 5,
+    "NightmareNestTask.json": 6,
+    "SimulationTask.json": 7,
+    "TacetTask.json": 8,
+}
+
+# 文件名 -> Schema
+CONFIG_SCHEMA_MAP: dict[str, dict[str, FieldSchema]] = {
+    "DailyTask.json": DAILY_TASK_SCHEMA,
+    "MultiAccountDailyTask.json": MULTI_ACCOUNT_DAILY_TASK_SCHEMA,
+    "FarmEchoTask.json": FARM_ECHO_TASK_SCHEMA,
+    "AutoRogueTask.json": AUTO_ROGUE_TASK_SCHEMA,
+    "ForgeryTask.json": FORGERY_TASK_SCHEMA,
+    "NightmareNestTask.json": NIGHTMARE_NEST_TASK_SCHEMA,
+    "SimulationTask.json": SIMULATION_TASK_SCHEMA,
+    "TacetTask.json": TACET_TASK_SCHEMA,
+    "EnhanceEchoTask.json": ENHANCE_ECHO_TASK_SCHEMA,
+    "AutoCombatTask.json": AUTO_COMBAT_TASK_SCHEMA,
+    "AutoPickTask.json": AUTO_PICK_TASK_SCHEMA,
+    "AutoDialogTask.json": AUTO_DIALOG_TASK_SCHEMA,
+    "ChangeEchoTask.json": CHANGE_ECHO_TASK_SCHEMA,
+    "Game Hotkey.json": GAME_HOTKEY_SCHEMA,
+    "Character Config.json": CHARACTER_CONFIG_SCHEMA,
+    "Monthly Card Config.json": MONTHLY_CARD_CONFIG_SCHEMA,
+    "Basic Options.json": BASIC_OPTIONS_SCHEMA,
+}
+
+
+def get_config_schema(filename: str) -> dict[str, FieldSchema] | None:
+    """获取指定配置文件的 schema"""
+    return CONFIG_SCHEMA_MAP.get(filename)
+
+
+def get_all_config_info() -> list[dict[str, Any]]:
+    """获取所有配置文件的元信息（用于前端列表展示）"""
+    result = []
+    for group_name, filenames in CONFIG_GROUPS.items():
+        for filename in filenames:
+            schema = CONFIG_SCHEMA_MAP.get(filename, {})
+            result.append({
+                "filename": filename,
+                "displayName": CONFIG_DISPLAY_NAMES.get(filename, filename),
+                "group": group_name,
+                "taskIndex": TASK_INDEX_MAP.get(filename),
+                "fieldCount": len(schema),
+            })
+    return result

--- a/app/task/Okww/manager.py
+++ b/app/task/Okww/manager.py
@@ -197,6 +197,10 @@ class OkwwManager(TaskExecuteBase):
         try:
             await self._restore_script_config_from_temp()
 
+            # 先解锁，再写回 UserData（load() 在锁定状态下会抛异常）
+            if script_cfg.is_locked:
+                await script_cfg.unlock()
+
             if self.check_result != "Pass" and not any(
                 user.status == "完成" for user in self.script_info.user_list
             ):
@@ -207,9 +211,6 @@ class OkwwManager(TaskExecuteBase):
 
             if self.task_info.mode == "AutoProxy" and hasattr(self, "user_config"):
                 await script_cfg.UserData.load(await self.user_config.toDict())
-
-            if script_cfg.is_locked:
-                await script_cfg.unlock()
 
             if any(user.status == "异常" for user in self.script_info.user_list):
                 self.script_info.status = "异常"
@@ -227,18 +228,19 @@ class OkwwManager(TaskExecuteBase):
 
         await self._restore_script_config_from_temp()
 
-        try:
-            if self.task_info.mode == "AutoProxy" and hasattr(self, "user_config"):
-                await Config.ScriptConfig[script_uid].UserData.load(
-                    await self.user_config.toDict()
-                )
-        except Exception:
-            logger.exception("on_crash 写回 UserConfig 失败，放弃本次状态变更")
-
+        # 先解锁，再写回 UserData（load() 在锁定状态下会抛异常）
         script_cfg = Config.ScriptConfig[script_uid]
         if script_cfg.is_locked:
             with suppress(Exception):
                 await script_cfg.unlock()
+
+        try:
+            if self.task_info.mode == "AutoProxy" and hasattr(self, "user_config"):
+                await script_cfg.UserData.load(
+                    await self.user_config.toDict()
+                )
+        except Exception:
+            logger.exception("on_crash 写回 UserConfig 失败，放弃本次状态变更")
         await Config.send_websocket_message(
             id=self.task_info.task_id,
             type="Info",

--- a/frontend/src/api/services/OkwwService.ts
+++ b/frontend/src/api/services/OkwwService.ts
@@ -1,0 +1,67 @@
+/* istanbul ignore file */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+
+export class OkwwService {
+    /**
+     * 获取 OK-WW 配置文件列表及 schema
+     */
+    public static getOkwwConfigsListApiScriptsOkwwConfigsListPost(
+        scriptId: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/scripts/okww/configs/list',
+            query: {
+                'script_id': scriptId,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+    /**
+     * 更新 OK-WW 配置文件
+     */
+    public static updateOkwwConfigApiScriptsOkwwConfigsUpdatePost(
+        scriptId: string,
+        filename: string,
+        data: Record<string, any>,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/scripts/okww/configs/update',
+            body: {
+                'script_id': scriptId,
+                'filename': filename,
+                'data': data,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+    /**
+     * 批量更新 OK-WW 配置文件
+     */
+    public static batchUpdateOkwwConfigsApiScriptsOkwwConfigsBatchUpdatePost(
+        scriptId: string,
+        configs: Record<string, Record<string, any>>,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/scripts/okww/configs/batch-update',
+            body: {
+                'script_id': scriptId,
+                'configs': configs,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+}

--- a/frontend/src/views/EditView/User/OkwwUserEdit.vue
+++ b/frontend/src/views/EditView/User/OkwwUserEdit.vue
@@ -1,26 +1,5 @@
 <template>
   <div class="user-edit-container">
-    <teleport to="body">
-      <div v-if="showConfigMask" class="maa-config-mask">
-        <div class="mask-content">
-          <div class="mask-icon">
-            <SettingOutlined :style="{ fontSize: '48px', color: 'var(--ant-color-primary)' }" />
-          </div>
-          <h2 class="mask-title">正在进行 ok-ww 配置</h2>
-          <p class="mask-description">
-            当前正在为这个用户打开 ok-ww 配置界面，请在 ok-ww 中完成相关设置。
-            <br />
-            配置完成后，点击“保存配置”结束本次会话。
-          </p>
-          <div class="mask-actions">
-            <a-button v-if="websocketId" type="primary" size="large" @click="handleSaveOkwwConfig">
-              保存配置
-            </a-button>
-          </div>
-        </div>
-      </div>
-    </teleport>
-
     <div class="user-edit-header">
       <div class="header-nav">
         <a-breadcrumb class="breadcrumb">
@@ -39,31 +18,6 @@
       </div>
 
       <a-space size="middle">
-        <a-button
-          v-if="formData.Info.Mode === '详细' && !showConfigMask"
-          type="primary"
-          ghost
-          size="large"
-          :loading="configLoading"
-          @click="handleOkwwConfig"
-        >
-          <template #icon>
-            <SettingOutlined />
-          </template>
-          ok-ww 配置
-        </a-button>
-        <a-button
-          v-if="formData.Info.Mode === '详细' && showConfigMask"
-          type="default"
-          size="large"
-          disabled
-          style="color: #52c41a; border-color: #52c41a"
-        >
-          <template #icon>
-            <SettingOutlined />
-          </template>
-          正在配置
-        </a-button>
         <a-button size="large" class="cancel-button" @click="handleCancel">
           <template #icon>
             <ArrowLeftOutlined />
@@ -160,28 +114,7 @@
             </a-row>
 
             <a-row :gutter="24">
-              <a-col :span="8">
-                <a-form-item>
-                  <template #label>
-                    <span class="form-label">
-                      用户配置模式
-                      <a-tooltip title="简洁模式共用脚本页配置；详细模式每个用户独立配置">
-                        <QuestionCircleOutlined class="help-icon" />
-                      </a-tooltip>
-                    </span>
-                  </template>
-                  <a-select
-                    v-model:value="formData.Info.Mode"
-                    size="large"
-                    class="modern-select"
-                    @change="handleModeChange"
-                  >
-                    <a-select-option value="简洁">简洁</a-select-option>
-                    <a-select-option value="详细">详细</a-select-option>
-                  </a-select>
-                </a-form-item>
-              </a-col>
-              <a-col :span="8">
+              <a-col :span="12">
                 <a-form-item>
                   <template #label>
                     <span class="form-label">
@@ -201,7 +134,7 @@
                   />
                 </a-form-item>
               </a-col>
-              <a-col :span="8">
+              <a-col :span="12">
                 <a-form-item>
                   <template #label>
                     <span class="form-label">
@@ -280,7 +213,16 @@
               </a-col>
             </a-row>
           </div>
+        </a-form>
+      </a-card>
 
+      <!-- OK-WW 配置编辑器 -->
+      <a-card class="config-card" style="margin-top: 24px">
+        <OkwwConfigEditor :script-id="scriptId" @saved="handleConfigSaved" />
+      </a-card>
+
+      <a-card class="config-card" style="margin-top: 24px">
+        <a-form :model="formData" layout="vertical" class="config-form">
           <div class="form-section">
             <div class="section-header">
               <h3>通知配置</h3>
@@ -368,12 +310,12 @@
 import { computed, nextTick, onMounted, reactive, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { message } from 'ant-design-vue'
-import { ArrowLeftOutlined, QuestionCircleOutlined, SettingOutlined } from '@ant-design/icons-vue'
-import { Service, TaskCreateIn, type OkwwUserConfig } from '@/api'
+import { ArrowLeftOutlined, QuestionCircleOutlined } from '@ant-design/icons-vue'
+import type { OkwwUserConfig } from '@/api'
 import { useUserApi } from '@/composables/useUserApi'
 import { useScriptApi } from '@/composables/useScriptApi'
-import { subscribe, unsubscribe } from '@/composables/useWebSocket'
 import WebhookManager from '@/components/WebhookManager.vue'
+import OkwwConfigEditor from '@/views/M9AUserEdit/OkwwConfigEditor.vue'
 
 const logger = window.electronAPI.getLogger('ok-ww用户编辑')
 const route = useRoute()
@@ -387,10 +329,6 @@ const isEdit = ref(!!userId)
 const scriptName = ref('ok-ww脚本')
 
 const pageLoading = ref(true)
-const showConfigMask = ref(false)
-const configLoading = ref(false)
-const subscriptionId = ref<string | null>(null)
-const websocketId = ref<string | null>(null)
 const isInitializing = ref(true)
 const isSaving = ref(false)
 
@@ -409,14 +347,6 @@ const okwwTaskOptions = [
   { label: '7 - SimulationTask（模拟领域）', value: 7 },
   { label: '8 - TacetTask（无音区）', value: 8 },
 ]
-
-type OkwwConfigMessage = {
-  type?: string
-  data?: {
-    Accomplish?: unknown
-    [key: string]: unknown
-  }
-}
 
 const getDefaultUserData = () => ({
   Info: {
@@ -516,11 +446,6 @@ const handleTaskIndexChange = async (value: number) => {
   }
 }
 
-const handleModeChange = async (value: '简洁' | '详细') => {
-  formData.Info.Mode = value
-  await saveField('Info.Mode', value)
-}
-
 const loadScriptInfo = async () => {
   const detail = await getScript(scriptId)
   if (detail) {
@@ -564,75 +489,8 @@ const loadUser = async () => {
   }
 }
 
-const cleanupWs = () => {
-  if (subscriptionId.value) {
-    unsubscribe(subscriptionId.value)
-    subscriptionId.value = null
-  }
-  websocketId.value = null
-  showConfigMask.value = false
-}
-
-const handleOkwwConfig = async () => {
-  if (!userId) {
-    message.error('用户未就绪，请稍后重试')
-    return
-  }
-  if (formData.Info.Mode !== '详细') {
-    message.info('当前为简洁模式，请在脚本页使用「配置 ok-ww」按钮')
-    return
-  }
-  try {
-    configLoading.value = true
-    cleanupWs()
-
-    const resp = await Service.addTaskApiDispatchStartPost({
-      taskId: userId,
-      mode: TaskCreateIn.mode.SCRIPT_CONFIG,
-    })
-
-    if (resp?.code !== 200 || !resp?.taskId) {
-      throw new Error(resp?.message || '启动 ok-ww 配置失败')
-    }
-
-    websocketId.value = resp.taskId
-    const subId = subscribe({ id: resp.taskId }, (wsMessage: OkwwConfigMessage) => {
-      if (wsMessage.type === 'error') {
-        message.error(`ok-ww 配置连接失败: ${wsMessage.data}`)
-        cleanupWs()
-        return
-      }
-      if (wsMessage.type === 'Signal' && wsMessage.data?.Accomplish !== undefined) {
-        cleanupWs()
-      }
-    })
-    subscriptionId.value = subId
-    showConfigMask.value = true
-    message.success('已开始 ok-ww 配置会话')
-  } catch (e) {
-    message.error(e instanceof Error ? e.message : '启动 ok-ww 配置失败')
-  } finally {
-    configLoading.value = false
-  }
-}
-
-const handleSaveOkwwConfig = async () => {
-  const wsId = websocketId.value
-  if (!wsId) {
-    message.error('未找到活动的配置会话')
-    return
-  }
-  try {
-    const resp = await Service.stopTaskApiDispatchStopPost({ taskId: wsId })
-    if (resp?.code === 200) {
-      cleanupWs()
-      message.success('ok-ww 配置已保存')
-    } else {
-      message.error(resp?.message || '保存配置失败')
-    }
-  } catch {
-    message.error('保存配置失败')
-  }
+const handleConfigSaved = () => {
+  logger.info('OK-WW 配置已保存')
 }
 
 onMounted(async () => {
@@ -735,57 +593,6 @@ onMounted(async () => {
 .modern-select :deep(.ant-select-selector) {
   border: 2px solid var(--ant-color-border) !important;
   border-radius: 8px !important;
-}
-
-/* 与 Scripts.vue / MAAUserEdit 配置遮罩一致 */
-.maa-config-mask {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.45);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 9999;
-}
-
-.mask-content {
-  background: var(--ant-color-bg-elevated);
-  border-radius: 8px;
-  padding: 24px;
-  max-width: 480px;
-  width: 100%;
-  text-align: center;
-  box-shadow:
-    0 6px 16px 0 rgba(0, 0, 0, 0.08),
-    0 3px 6px -4px rgba(0, 0, 0, 0.12),
-    0 9px 28px 8px rgba(0, 0, 0, 0.05);
-  border: 1px solid var(--ant-color-border);
-}
-
-.mask-icon {
-  margin-bottom: 16px;
-}
-
-.mask-title {
-  font-size: 18px;
-  font-weight: 600;
-  margin: 0 0 8px;
-  color: var(--ant-color-text);
-}
-
-.mask-description {
-  font-size: 14px;
-  color: var(--ant-color-text-secondary);
-  margin: 0 0 24px;
-  line-height: 1.5;
-}
-
-.mask-actions {
-  display: flex;
-  justify-content: center;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/views/M9AUserEdit/OkwwConfigEditor.vue
+++ b/frontend/src/views/M9AUserEdit/OkwwConfigEditor.vue
@@ -1,0 +1,510 @@
+<template>
+  <div class="okww-config-editor">
+    <div class="editor-header">
+      <h3>OK-WW 配置编辑</h3>
+      <a-tag v-if="hasChanges" color="warning">有未保存的更改</a-tag>
+      <a-tag v-else color="success">已保存</a-tag>
+    </div>
+
+    <a-spin :spinning="loading" tip="加载配置中...">
+      <a-row :gutter="24" class="editor-layout">
+        <!-- 左侧：配置文件列表 -->
+        <a-col :span="8" class="left-panel">
+          <div class="config-groups">
+            <div
+              v-for="(group, groupName) in groupedConfigs"
+              :key="groupName"
+              class="config-group"
+            >
+              <div class="group-header">{{ groupName }}</div>
+              <div class="group-items">
+                <div
+                  v-for="config in group"
+                  :key="config.filename"
+                  class="config-item"
+                  :class="{
+                    'config-item--active': selectedFilename === config.filename,
+                    'config-item--changed': changedFiles.has(config.filename),
+                  }"
+                  @click="selectConfig(config.filename)"
+                >
+                  <div class="config-item-info">
+                    <span class="config-item-name">{{ config.displayName }}</span>
+                    <span v-if="config.taskIndex" class="config-item-badge">
+                      -t {{ config.taskIndex }}
+                    </span>
+                  </div>
+                  <span v-if="changedFiles.has(config.filename)" class="config-item-dot" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </a-col>
+
+        <!-- 右侧：配置表单 -->
+        <a-col :span="16" class="right-panel">
+          <div v-if="selectedConfig" class="config-form">
+            <div class="form-header">
+              <h4>{{ selectedConfig.displayName }}</h4>
+              <span class="form-filename">{{ selectedConfig.filename }}</span>
+            </div>
+
+            <a-form layout="vertical" class="form-fields">
+              <a-form-item
+                v-for="field in selectedConfig.fields"
+                :key="field.name"
+                :label="field.label || field.name"
+              >
+                <template #extra v-if="field.description">
+                  {{ field.description }}
+                </template>
+
+                <!-- bool 类型：开关 -->
+                <a-switch
+                  v-if="field.type === 'bool'"
+                  :checked="getFieldValue(selectedConfig.filename, field.name, field.value)"
+                  @change="(val: boolean) => setFieldValue(selectedConfig.filename, field.name, val)"
+                />
+
+                <!-- select 类型：下拉选择 -->
+                <a-select
+                  v-else-if="field.type === 'select'"
+                  :value="getFieldValue(selectedConfig.filename, field.name, field.value)"
+                  style="width: 100%"
+                  @change="(val: string) => setFieldValue(selectedConfig.filename, field.name, val)"
+                >
+                  <a-select-option
+                    v-for="opt in (field.options || [])"
+                    :key="opt"
+                    :value="opt"
+                  >
+                    {{ getOptionLabel(opt) }}
+                  </a-select-option>
+                </a-select>
+
+                <!-- list 类型：多选 -->
+                <a-select
+                  v-else-if="field.type === 'list'"
+                  :value="getFieldValue(selectedConfig.filename, field.name, field.value)"
+                  mode="multiple"
+                  style="width: 100%"
+                  placeholder="请选择"
+                  @change="(val: string[]) => setFieldValue(selectedConfig.filename, field.name, val)"
+                >
+                  <a-select-option
+                    v-for="opt in (field.options || [])"
+                    :key="opt"
+                    :value="opt"
+                  >
+                    {{ getOptionLabel(opt) }}
+                  </a-select-option>
+                </a-select>
+
+                <!-- int 类型：整数输入 -->
+                <a-input-number
+                  v-else-if="field.type === 'int'"
+                  :value="getFieldValue(selectedConfig.filename, field.name, field.value)"
+                  :min="field.min"
+                  :max="field.max"
+                  style="width: 100%"
+                  @change="(val: number | null) => { if (val !== null) setFieldValue(selectedConfig.filename, field.name, val) }"
+                />
+
+                <!-- float 类型：浮点数输入 -->
+                <a-input-number
+                  v-else-if="field.type === 'float'"
+                  :value="getFieldValue(selectedConfig.filename, field.name, field.value)"
+                  :min="field.min"
+                  :max="field.max"
+                  :step="field.step || 0.1"
+                  style="width: 100%"
+                  @change="(val: number | null) => { if (val !== null) setFieldValue(selectedConfig.filename, field.name, val) }"
+                />
+
+                <!-- hotkey 类型：快捷键输入 -->
+                <a-input
+                  v-else-if="field.type === 'hotkey'"
+                  :value="getFieldValue(selectedConfig.filename, field.name, field.value)"
+                  style="width: 100%"
+                  @change="(e: Event) => setFieldValue(selectedConfig.filename, field.name, (e.target as HTMLInputElement).value)"
+                />
+
+                <!-- string 类型：文本输入 -->
+                <a-input
+                  v-else
+                  :value="getFieldValue(selectedConfig.filename, field.name, field.value)"
+                  style="width: 100%"
+                  @change="(e: Event) => setFieldValue(selectedConfig.filename, field.name, (e.target as HTMLInputElement).value)"
+                />
+              </a-form-item>
+
+              <div v-if="selectedConfig.fields.length === 0" class="empty-fields">
+                <a-empty description="该配置文件暂无可编辑的字段" />
+              </div>
+            </a-form>
+          </div>
+
+          <div v-else class="no-selection">
+            <a-empty description="请从左侧选择一个配置文件" />
+          </div>
+        </a-col>
+      </a-row>
+    </a-spin>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
+import { message } from 'ant-design-vue'
+import { OkwwService } from '@/api/services/OkwwService'
+
+interface ConfigField {
+  name: string
+  type: string
+  label: string
+  description: string
+  value: any
+  options: string[] | null
+  min: number | null
+  max: number | null
+  step: number | null
+}
+
+interface ConfigFile {
+  filename: string
+  displayName: string
+  group: string
+  taskIndex: number | null
+  fieldCount: number
+  fields: ConfigField[]
+  currentData: Record<string, any>
+}
+
+const props = defineProps<{
+  scriptId: string
+}>()
+
+const emit = defineEmits<{
+  saved: []
+}>()
+
+const logger = window.electronAPI.getLogger('OKWW配置编辑')
+
+const loading = ref(false)
+const saving = ref(false)
+const configs = ref<ConfigFile[]>([])
+const selectedFilename = ref<string | null>(null)
+const changedFiles = ref(new Set<string>())
+const localChanges = ref<Record<string, Record<string, any>>>({})
+const optionLabels = ref<Record<string, string>>({})
+
+const groupedConfigs = computed(() => {
+  const groups: Record<string, ConfigFile[]> = {}
+  for (const config of configs.value) {
+    const group = config.group || '其他'
+    if (!groups[group]) groups[group] = []
+    groups[group].push(config)
+  }
+  return groups
+})
+
+const selectedConfig = computed(() => {
+  if (!selectedFilename.value) return null
+  return configs.value.find(c => c.filename === selectedFilename.value) || null
+})
+
+const hasChanges = computed(() => changedFiles.value.size > 0)
+
+const getOptionLabel = (value: string) => {
+  return optionLabels.value[value] || value
+}
+
+const getFieldValue = (filename: string, fieldName: string, fallback: any) => {
+  if (localChanges.value[filename] && localChanges.value[filename][fieldName] !== undefined) {
+    return localChanges.value[filename][fieldName]
+  }
+  return fallback
+}
+
+const setFieldValue = (filename: string, fieldName: string, value: any) => {
+  if (!localChanges.value[filename]) {
+    localChanges.value[filename] = {}
+  }
+
+  // 比较原始值
+  const config = configs.value.find(c => c.filename === filename)
+  const field = config?.fields.find(f => f.name === fieldName)
+  const originalValue = field?.value
+
+  if (JSON.stringify(value) === JSON.stringify(originalValue)) {
+    delete localChanges.value[filename][fieldName]
+    if (Object.keys(localChanges.value[filename]).length === 0) {
+      delete localChanges.value[filename]
+      changedFiles.value.delete(filename)
+    }
+  } else {
+    localChanges.value[filename][fieldName] = value
+    changedFiles.value.add(filename)
+  }
+  // 触发响应式更新
+  changedFiles.value = new Set(changedFiles.value)
+}
+
+const selectConfig = (filename: string) => {
+  selectedFilename.value = filename
+}
+
+const loadConfigs = async () => {
+  loading.value = true
+  try {
+    const resp = await OkwwService.getOkwwConfigsListApiScriptsOkwwConfigsListPost(props.scriptId)
+    if (resp?.code === 200 && resp?.data) {
+      configs.value = resp.data
+      optionLabels.value = resp.optionLabels || {}
+      // 默认选中第一个
+      if (configs.value.length > 0 && !selectedFilename.value) {
+        selectedFilename.value = configs.value[0].filename
+      }
+    } else {
+      message.error(resp?.message || '加载配置失败')
+    }
+  } catch (e) {
+    logger.error(`加载配置失败: ${e instanceof Error ? e.message : String(e)}`)
+    message.error('加载 OK-WW 配置失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+const saveAll = async (silent = true) => {
+  if (!hasChanges.value) return
+  saving.value = true
+  try {
+    const configsToUpdate = { ...localChanges.value }
+    const resp = await OkwwService.batchUpdateOkwwConfigsApiScriptsOkwwConfigsBatchUpdatePost(
+      props.scriptId,
+      configsToUpdate
+    )
+    if (resp?.code === 200) {
+      // 更新本地数据
+      for (const [filename, data] of Object.entries(configsToUpdate)) {
+        const config = configs.value.find(c => c.filename === filename)
+        if (config) {
+          Object.assign(config.currentData, data)
+          for (const field of config.fields) {
+            if (data[field.name] !== undefined) {
+              field.value = data[field.name]
+            }
+          }
+        }
+      }
+      changedFiles.value = new Set()
+      localChanges.value = {}
+      emit('saved')
+      if (!silent) {
+        message.success('配置已保存')
+      }
+    } else {
+      message.error(resp?.message || '保存失败')
+    }
+  } catch (e) {
+    logger.error(`保存配置失败: ${e instanceof Error ? e.message : String(e)}`)
+    message.error('保存配置失败')
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(() => {
+  loadConfigs()
+})
+
+onBeforeUnmount(async () => {
+  if (hasChanges.value) {
+    await saveAll(true)
+  }
+})
+
+watch(() => props.scriptId, () => {
+  if (props.scriptId) {
+    loadConfigs()
+  }
+})
+</script>
+
+<style scoped>
+.okww-config-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.editor-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 16px;
+  border-bottom: 2px solid var(--ant-color-border-secondary);
+}
+
+.editor-header h3 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.editor-header h3::before {
+  content: '';
+  width: 4px;
+  height: 24px;
+  background: linear-gradient(135deg, var(--ant-color-primary), var(--ant-color-primary-hover));
+  border-radius: 2px;
+}
+
+.editor-layout {
+  min-height: 500px;
+}
+
+.left-panel {
+  border-right: 1px solid var(--ant-color-border);
+  padding-right: 24px;
+  overflow-y: auto;
+  max-height: 600px;
+}
+
+.config-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.group-header {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ant-color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 8px 12px 4px;
+}
+
+.group-items {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.config-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border-left: 3px solid transparent;
+}
+
+.config-item:hover {
+  background-color: var(--ant-color-primary-bg-hover);
+  border-left-color: var(--ant-color-primary);
+}
+
+.config-item--active {
+  background-color: var(--ant-color-primary-bg) !important;
+  border-left-color: var(--ant-color-primary) !important;
+}
+
+.config-item--changed {
+  background-color: var(--ant-color-warning-bg);
+}
+
+.config-item-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.config-item-name {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--ant-color-text);
+}
+
+.config-item-badge {
+  font-size: 11px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--ant-color-fill-secondary);
+  color: var(--ant-color-text-secondary);
+}
+
+.config-item-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--ant-color-warning);
+  flex-shrink: 0;
+}
+
+.right-panel {
+  padding-left: 24px;
+}
+
+.config-form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.form-header {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--ant-color-border-secondary);
+}
+
+.form-header h4 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--ant-color-text);
+}
+
+.form-filename {
+  font-size: 12px;
+  color: var(--ant-color-text-tertiary);
+  font-family: monospace;
+}
+
+.form-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-fields :deep(.ant-form-item) {
+  margin-bottom: 12px;
+}
+
+.form-fields :deep(.ant-form-item-label) {
+  font-weight: 600;
+}
+
+.empty-fields {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 200px;
+}
+
+.no-selection {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 400px;
+}
+</style>

--- a/res/version.json
+++ b/res/version.json
@@ -2,6 +2,12 @@
     "version": "v5.3.0-beta.3",
     "version_info": {
         "v5.3.0-beta.3": {
+            "新增功能": [
+                "okww专项 新增前端表单化配置编辑器，支持直接在 MAS 编辑 ok-ww 配置，无需启动 ok-ww GUI",
+                "okww专项 配置编辑器覆盖 17 个配置文件（8 任务 + 5 子配置 + 4 全局配置），支持 bool/int/float/string/select/list/hotkey 字段类型",
+                "okww专项 配置编辑器选项值中文翻译（如 Forgery Challenge 显示为凝素领域），配置文件中仍存储英文原值",
+                "okww专项 配置目录自动初始化，per-user 目录为空时自动从 ok-ww configs 复制默认配置"
+            ],
             "程序优化": [
                 "优化模拟器搜索功能",
                 "优化模拟器管理页面样式",
@@ -15,6 +21,8 @@
                 "okww专项 配置会话保存先校验源配置存在，避免源缺失时清空 MAS 侧旧配置",
                 "okww专项 任务收尾时若原 ok-ww 配置不存在则清理任务期写入的临时配置，不再留下空目录",
                 "okww专项 Game.Type 移除模拟器选项，仅保留 Client / URL",
+                "okww专项 移除用户编辑页的详细/简洁模式切换，配置编辑器替代 ok-ww GUI 配置会话",
+                "okww专项 配置编辑器退出页面时自动保存，无需手动点击",
                 "MAAEND专项 配置重构，优化样式",
                 "MAAEND专项 优化日志展示，显示未完成的任务"
             ],
@@ -24,6 +32,7 @@
                 "okww专项 修复多用户 AutoProxy 只执行最后一个用户的问题",
                 "okww专项 单用户配置文件检查下沉到逐用户校验，避免前面的用户配置缺失被忽略",
                 "okww专项 异常路径下对 user_config 是否已加载做防护，避免 prepare 之前抛错时再次触发 AttributeError",
+                "okww专项 修复手动终止任务时 final_task/on_crash 因配置锁定导致 UserData 写回失败的问题",
                 "游戏管理 MAS 接管启动时若游戏客户端已在运行则跳过重复拉起"
             ]
         },


### PR DESCRIPTION
## 改动概述

新增 ok-ww 配置的前端表单化编辑功能，用户可以直接在 MAS 前端编辑 ok-ww 的各项配置，**不再需要启动 ok-ww GUI** 完成配置步骤。

## 改动文件

| 文件 | 改动 |
|------|------|
|  | 新增：定义 17 个配置文件的字段 schema 和选项中文翻译 |
|  | 新增：3 个 ok-ww 配置 API 端点（list/update/batch-update） |
|  | 新增：前端 API 服务 |
|  | 新增：表单化配置编辑器组件 |
|  | 修改：移除详细/简洁模式，集成配置编辑器 |
|  | 修改：移除配置文件存在性强制检查 |
|  | 修复：final_task/on_crash 中配置锁定导致无法写回 UserData |

## 核心功能

1. **表单化编辑**：支持 bool/int/float/string/select/list/hotkey 等字段类型的表单控件
2. **选项中文翻译**：下拉选项显示中文（如 Forgery Challenge → 凝素领域），配置文件中仍存储英文原值
3. **自动初始化**：per-user 配置目录为空时自动从 ok-ww configs 复制默认配置
4. **自动保存**：退出用户编辑页面时自动保存所有更改
5. **配置覆盖**：17 个配置文件全覆盖（8 个任务配置 + 5 个任务子配置 + 4 个全局配置）

## 数据流

```
用户编辑 → data/{script_id}/Default/ConfigFile/ → ok-ww configs → 运行 → 回写 → 恢复
```