### PR TITLE
refactor(okww): 收窄 ErrorLog 默认关键词为 info_set 错误，移除前端表单隐性默认值

### DIFF
--- a/app/models/config.py
+++ b/app/models/config.py
@@ -2101,7 +2101,7 @@ class OkwwConfig(ConfigBase):
         self.Script_ErrorLog = ConfigItem(
             "Script",
             "ErrorLog",
-            "connected:False|游戏更新成功, 游戏即将重启|错误",
+            "connected:False|游戏更新成功, 游戏即将重启|info_set 错误",
         )
 
         ## Game ------------------------------------------------------------

--- a/app/task/Okww/AutoProxy.py
+++ b/app/task/Okww/AutoProxy.py
@@ -50,7 +50,7 @@ _OKWW_BUILTIN_FATAL: tuple[tuple[str, str], ...] = (
 )
 
 # prepare 中 ErrorLog 经清洗后为空时回退（与 OkwwConfig 默认串一致）
-_DEFAULT_OKWW_ERROR_LOG = "connected:False|游戏更新成功, 游戏即将重启|错误"
+_DEFAULT_OKWW_ERROR_LOG = "connected:False|游戏更新成功, 游戏即将重启|info_set 错误"
 
 
 def _split_args(raw: object) -> list[str]:

--- a/frontend/src/views/EditView/Script/OkwwScriptEdit.vue
+++ b/frontend/src/views/EditView/Script/OkwwScriptEdit.vue
@@ -348,8 +348,8 @@ const okwwConfig = reactive<OkwwConfig>({
     LogTimeStart: 1,
     LogTimeEnd: 23,
     LogTimeFormat: '%Y-%m-%d %H:%M:%S,%f',
-    SuccessLog: '任务执行完成 | task completed',
-    ErrorLog: 'connected:False|游戏更新成功, 游戏即将重启|错误',
+    SuccessLog: '',
+    ErrorLog: '',
   },
   Game: {
     Enabled: false,


### PR DESCRIPTION
## 变更摘要

### 问题
okww 的 `_DEFAULT_OKWW_ERROR_LOG` 回退关键词中使用过宽的 `错误` 作为匹配词，容易在 ok-ww 正常日志中误撞，导致任务误判为失败。

### 修改

1. **收窄 ErrorLog 默认关键词**
   - `_DEFAULT_OKWW_ERROR_LOG`: `错误` → `info_set 错误`
   - `OkwwConfig` 后端默认值同步

2. **移除前端表单隐性默认值**
   - `OkwwScriptEdit.vue` 中 `SuccessLog` / `ErrorLog` 两个字段从未在 Okww 表单 UI 中暴露为可编辑项，却带着硬编码默认值静默写入配置
   - 改为空字符串，完全交由后端兜底（`_DEFAULT_OKWW_ERROR_LOG` / `_okww_log_indicates_success`）
   - 已有脚本不受影响：`loadScript` 通过 `Object.assign` 从服务端配置回填

### 影响范围
- 仅新建 okww 脚本时生效
- 已有脚本的 ErrorLog/SuccessLog 配置保持不变
- 误判风险显著降低：`info_set 错误` 比 `错误` 精准得多