### PR TITLE
refactor(core): SCRIPT_REGISTRY 权威单源，新增专项适配从 15+ 处注册缩减为 2 处

### DIFF
--- a/.agents/skills/mas-script-specialized-adapter/SKILL.md
+++ b/.agents/skills/mas-script-specialized-adapter/SKILL.md
@@ -113,9 +113,9 @@ description: >-
 ### 阶段 3：后端注册
 12. `app/models/config.py`：`XxxConfig` / `XxxUserConfig`
 13. `app/models/schema.py`：schema 注册
-14. `app/core/config.py`：`isinstance` 分支
-15. `app/api/scripts.py`：`SCRIPT_BOOK` / `USER_BOOK`
-16. `app/utils/constants.py`：`TYPE_BOOK` 展示文案
+14. `app/core/config.py`：Manager dispatch map（_SCRIPT_MANAGER_MAP）
+15. `app/api/scripts.py`：`SCRIPT_BOOK` / `USER_BOOK`（从 SCRIPT_REGISTRY 自动派生）
+16. `app/models/config.py`：`SCRIPT_REGISTRY` 注册（`TYPE_BOOK` 自动派生）
 17. `yarn openapi` → 确认 `openapi.json` 含新类型
 
 ### 阶段 4：任务模块

--- a/.agents/skills/mas-script-specialized-adapter/references/adapter-code-norms.md
+++ b/.agents/skills/mas-script-specialized-adapter/references/adapter-code-norms.md
@@ -8,7 +8,7 @@
 |------|------|
 | `XxxConfig` / `XxxUserConfig` + `schema.py` | `app/models/` |
 | `SCRIPT_BOOK`、`USER_BOOK`、`task_manager` 分支 | `app/core/`、`app/models/config.py` |
-| `TYPE_BOOK["XxxConfig"]` → 展示文案 | `app/utils/constants.py`（否则调度 `combox/task` KeyError） |
+| `SCRIPT_REGISTRY` 注册（Config+UserConfig+展示名） | `app/models/config.py`（`TYPE_BOOK` 自动派生） |
 | 后端改 schema 后 `yarn openapi` | `frontend/`；**禁止**手改 `src/api/models/*` |
 | OpenAPI 生效 | 重启后端 → `openapi.json` **文本**含新类型名（勿只靠 PowerShell 对象键）→ 确认 36163 为当前 `main.py` |
 

--- a/app/api/scripts.py
+++ b/app/api/scripts.py
@@ -29,6 +29,7 @@ from typing import Any, Literal
 from fastapi import APIRouter, Body
 
 from app.core import Config
+from app.models.config import SCRIPT_REGISTRY
 from app.models.schema import *
 
 router = APIRouter(prefix="/api/scripts", tags=["脚本管理"])
@@ -49,24 +50,18 @@ def _okww_config_file_path(config_dir: Path, filename: str) -> Path:
     return config_dir / filename
 
 
-SCRIPT_BOOK = {
-    "MaaConfig": MaaConfig,
-    "SrcConfig": SrcConfig,
-    "MaaEndConfig": MaaEndConfig,
-    "M9AConfig": M9AConfig,
-    "GeneralConfig": GeneralConfig,
-    "OkwwConfig": OkwwConfig,
-    "HSRConfig": HSRConfig,
-}
-USER_BOOK = {
-    "MaaConfig": MaaUserConfig,
-    "SrcConfig": SrcUserConfig,
-    "MaaEndConfig": MaaEndUserConfig,
-    "M9AConfig": M9AUserConfig,
-    "GeneralConfig": GeneralUserConfig,
-    "OkwwConfig": OkwwUserConfig,
-    "HSRConfig": HSRUserConfig,
-}
+# 从 SCRIPT_REGISTRY 自动派生 —— 键为 ConfigBase.__name__，值为对应 schema.py Pydantic 类
+def _pick_schema(name: str) -> type:
+    cls = globals().get(name)
+    if cls is None:
+        raise ImportError(f"schema.py 缺少 {name}（需与 config.py 同名）")
+    return cls
+
+_SCRIPTS_REG = SCRIPT_REGISTRY  # 别名避免与 schema 中的同名符号冲突
+SCRIPT_BOOK = {v.config.__name__: _pick_schema(v.config.__name__)
+               for v in _SCRIPTS_REG.values()}
+USER_BOOK = {v.config.__name__: _pick_schema(v.user_config.__name__)
+             for v in _SCRIPTS_REG.values() if v.user_config is not None}
 
 
 @router.post(

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -58,6 +58,8 @@ from app.models.config import (
     OkwwUserConfig,
     GlobalConfig,
     CLASS_BOOK,
+    SCRIPT_USER_CONFIG_MAP,
+    TYPE_BOOK,
     Webhook,
     TimeSet,
     EmulatorConfig,
@@ -68,7 +70,6 @@ from app.utils.constants import (
     UTC8,
     RESOURCE_STAGE_INFO,
     RESOURCE_STAGE_DROP_INFO,
-    TYPE_BOOK,
     RESOURCE_STAGE_DATE_TEXT,
 )
 from app.utils import get_logger
@@ -532,7 +533,7 @@ class AppConfig(GlobalConfig):
 
     async def add_script(
         self,
-        script: Literal["MAA", "SRC", "General", "MaaEnd", "M9A", "Okww", "HSR"],
+        script: str,
         script_id: str | None = None,
     ) -> tuple[
         uuid.UUID,
@@ -830,23 +831,11 @@ class AppConfig(GlobalConfig):
 
         script_config = self.ScriptConfig[uuid.UUID(script_id)]
 
-        # 根据脚本类型选择添加对应用户配置
-        if isinstance(script_config, MaaConfig):
-            uid, config = await script_config.UserData.add(MaaUserConfig)
-        elif isinstance(script_config, SrcConfig):
-            uid, config = await script_config.UserData.add(SrcUserConfig)
-        elif isinstance(script_config, GeneralConfig):
-            uid, config = await script_config.UserData.add(GeneralUserConfig)
-        elif isinstance(script_config, OkwwConfig):
-            uid, config = await script_config.UserData.add(OkwwUserConfig)
-        elif isinstance(script_config, MaaEndConfig):
-            uid, config = await script_config.UserData.add(MaaEndUserConfig)
-        elif isinstance(script_config, M9AConfig):
-            uid, config = await script_config.UserData.add(M9AUserConfig)
-        elif isinstance(script_config, HSRConfig):
-            uid, config = await script_config.UserData.add(HSRUserConfig)
-        else:
+        # 根据脚本类型分发（从 SCRIPT_REGISTRY 自动派生）
+        user_cls = SCRIPT_USER_CONFIG_MAP.get(type(script_config))
+        if user_cls is None:
             raise TypeError(f"不支持的脚本配置类型: {type(script_config)}")
+        uid, config = await script_config.UserData.add(user_cls)
 
         return uid, config
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -58,6 +58,7 @@ from app.models.config import (
     OkwwUserConfig,
     GlobalConfig,
     CLASS_BOOK,
+    SCRIPT_REGISTRY,
     SCRIPT_USER_CONFIG_MAP,
     TYPE_BOOK,
     Webhook,
@@ -540,6 +541,9 @@ class AppConfig(GlobalConfig):
         MaaConfig | SrcConfig | GeneralConfig | MaaEndConfig | M9AConfig | OkwwConfig | HSRConfig,
     ]:
         """添加脚本配置"""
+
+        if script not in SCRIPT_REGISTRY:
+            raise ValueError(f"未知脚本类型: {script}")
 
         logger.info(f"添加脚本配置: {script}, 从 {script_id} 复制")
 

--- a/app/core/task_manager.py
+++ b/app/core/task_manager.py
@@ -29,28 +29,16 @@ from app.services import System
 from app.models.config import SCRIPT_REGISTRY
 from app.models.task import TaskItem, ScriptItem, UserItem, TaskExecuteBase
 from app.utils import get_logger
-from app.task import (
-    MaaManager,
-    SrcManager,
-    GeneralManager,
-    MaaEndManager,
-    M9AManager,
-    OkwwManager,
-    HSRManager,
-)
+import app.task as _task_module
 from app.utils.constants import POWER_SIGN_MAP
 
 # ── Manager 分发：遵循 XxxConfig → XxxManager 命名约定，从 SCRIPT_REGISTRY 自动派生 ──
-_MANAGER_BY_NAME = {
-    cls.__name__: cls
-    for cls in (MaaManager, SrcManager, GeneralManager, MaaEndManager,
-                M9AManager, OkwwManager, HSRManager)
-}
 _SCRIPT_MANAGER_MAP: dict[type, type] = {}
 for _ad in SCRIPT_REGISTRY.values():
-    _name = _ad.config.__name__.replace("Config", "Manager")
-    if _name in _MANAGER_BY_NAME:
-        _SCRIPT_MANAGER_MAP[_ad.config] = _MANAGER_BY_NAME[_name]
+    _manager_name = _ad.config.__name__.replace("Config", "Manager")
+    _manager_cls = getattr(_task_module, _manager_name, None)
+    if _manager_cls is not None:
+        _SCRIPT_MANAGER_MAP[_ad.config] = _manager_cls
 
 
 logger = get_logger("业务调度")

--- a/app/core/task_manager.py
+++ b/app/core/task_manager.py
@@ -24,17 +24,9 @@ import uuid
 import asyncio
 from typing import Dict, Literal
 
-from .config import (
-    Config,
-    MaaConfig,
-    SrcConfig,
-    GeneralConfig,
-    MaaEndConfig,
-    M9AConfig,
-    OkwwConfig,
-    HSRConfig,
-)
+from .config import Config
 from app.services import System
+from app.models.config import SCRIPT_REGISTRY
 from app.models.task import TaskItem, ScriptItem, UserItem, TaskExecuteBase
 from app.utils import get_logger
 from app.task import (
@@ -47,6 +39,18 @@ from app.task import (
     HSRManager,
 )
 from app.utils.constants import POWER_SIGN_MAP
+
+# ── Manager 分发：遵循 XxxConfig → XxxManager 命名约定，从 SCRIPT_REGISTRY 自动派生 ──
+_MANAGER_BY_NAME = {
+    cls.__name__: cls
+    for cls in (MaaManager, SrcManager, GeneralManager, MaaEndManager,
+                M9AManager, OkwwManager, HSRManager)
+}
+_SCRIPT_MANAGER_MAP: dict[type, type] = {}
+for _ad in SCRIPT_REGISTRY.values():
+    _name = _ad.config.__name__.replace("Config", "Manager")
+    if _name in _MANAGER_BY_NAME:
+        _SCRIPT_MANAGER_MAP[_ad.config] = _MANAGER_BY_NAME[_name]
 
 
 logger = get_logger("业务调度")
@@ -168,21 +172,10 @@ class Task(TaskExecuteBase):
             script_item.status = "运行"
             logger.info(f"任务开始: {current_script_uid}")
 
-            if isinstance(Config.ScriptConfig[current_script_uid], MaaConfig):
-                task_item = MaaManager(script_item)
-            elif isinstance(Config.ScriptConfig[current_script_uid], SrcConfig):
-                task_item = SrcManager(script_item)
-            elif isinstance(Config.ScriptConfig[current_script_uid], GeneralConfig):
-                task_item = GeneralManager(script_item)
-            elif isinstance(Config.ScriptConfig[current_script_uid], OkwwConfig):
-                task_item = OkwwManager(script_item)
-            elif isinstance(Config.ScriptConfig[current_script_uid], MaaEndConfig):
-                task_item = MaaEndManager(script_item)
-            elif isinstance(Config.ScriptConfig[current_script_uid], M9AConfig):
-                task_item = M9AManager(script_item)
-            elif isinstance(Config.ScriptConfig[current_script_uid], HSRConfig):
-                task_item = HSRManager(script_item)
-            else:
+            manager_cls = _SCRIPT_MANAGER_MAP.get(
+                type(Config.ScriptConfig[current_script_uid])
+            )
+            if manager_cls is None:
                 logger.error(
                     f"不支持的脚本类型: {type(Config.ScriptConfig[current_script_uid]).__name__}"
                 )
@@ -192,6 +185,7 @@ class Task(TaskExecuteBase):
                     data={"Error": "脚本类型不支持"},
                 )
                 continue
+            task_item = manager_cls(script_item)
 
             # 运行任务
             await self.spawn(task_item)

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -24,7 +24,7 @@ import json
 import calendar
 from pathlib import Path
 from datetime import datetime
-from typing import Callable
+from typing import Callable, NamedTuple
 
 from app.utils.constants import (
     UTC4,
@@ -2814,21 +2814,15 @@ class GlobalConfig(ConfigBase):
         self.EmulatorConfig = MultipleConfig([EmulatorConfig])
         ## 计划表配置列表
         self.PlanConfig = MultipleConfig([MaaPlanConfig])
-        ## 脚本配置列表
-        self.ScriptConfig = MultipleConfig(
-            [MaaConfig, MaaEndConfig, SrcConfig, M9AConfig, GeneralConfig, OkwwConfig, HSRConfig]
-        )
+        ## 脚本配置列表（从 SCRIPT_REGISTRY 自动派生）
+        self.ScriptConfig = MultipleConfig(SCRIPT_CONFIG_CLASSES)  # type: ignore[arg-type]
         ## 队列配置列表
         self.QueueConfig = MultipleConfig([QueueConfig])
         ## 工具箱配置
         self.ToolsConfig = ToolsConfig()
 
-        MaaConfig.related_config["EmulatorConfig"] = self.EmulatorConfig
-        MaaEndConfig.related_config["EmulatorConfig"] = self.EmulatorConfig
-        SrcConfig.related_config["EmulatorConfig"] = self.EmulatorConfig
-        M9AConfig.related_config["EmulatorConfig"] = self.EmulatorConfig
-        GeneralConfig.related_config["EmulatorConfig"] = self.EmulatorConfig
-        OkwwConfig.related_config["EmulatorConfig"] = self.EmulatorConfig
+        for cls in SCRIPT_CONFIG_CLASSES:
+            cls.related_config["EmulatorConfig"] = self.EmulatorConfig
         MaaUserConfig.related_config["PlanConfig"] = self.PlanConfig
         QueueItem.related_config["ScriptConfig"] = self.ScriptConfig
 
@@ -2895,14 +2889,40 @@ class GlobalConfig(ConfigBase):
         return json.dumps(stage_data, ensure_ascii=False)
 
 
-CLASS_BOOK = {
-    "MAA": MaaConfig,
-    "MaaPlan": MaaPlanConfig,
-    "SRC": SrcConfig,
-    "MaaEnd": MaaEndConfig,
-    "M9A": M9AConfig,
-    "General": GeneralConfig,
-    "Okww": OkwwConfig,
-    "HSR": HSRConfig,
+# ═══════════════════════════════════════════════════════════════════════════
+# 脚本专项注册表（唯一真源）
+# 新增脚本适配时只需在此加一行，其余 CLASS_BOOK / SCRIPT_BOOK / USER_BOOK /
+# MultipleConfig 列表 / display 名称全部自动派生。
+# ═══════════════════════════════════════════════════════════════════════════
+class _Adapter(NamedTuple):
+    config: type
+    user_config: type | None = None
+    display: str = ""
+
+SCRIPT_REGISTRY: dict[str, _Adapter] = {
+    "MAA":     _Adapter(MaaConfig,     MaaUserConfig,     "MAA计划"),
+    "SRC":     _Adapter(SrcConfig,     SrcUserConfig,     "SRC"),
+    "General": _Adapter(GeneralConfig, GeneralUserConfig, "通用脚本"),
+    "MaaEnd":  _Adapter(MaaEndConfig,  MaaEndUserConfig,  "MaaEnd"),
+    "M9A":     _Adapter(M9AConfig,     M9AUserConfig,     "M9A"),
+    "Okww":    _Adapter(OkwwConfig,    OkwwUserConfig,    "ok-ww"),
+    "HSR":     _Adapter(HSRConfig,     HSRUserConfig,     "HSR"),
 }
-"""配置类映射表"""
+
+# ── 以下全部从 SCRIPT_REGISTRY 自动派生，新增专项时无需手动修改 ──────────
+CLASS_BOOK = {k: v.config for k, v in SCRIPT_REGISTRY.items()}
+CLASS_BOOK["MaaPlan"] = MaaPlanConfig  # MAA 计划表非脚本适配器，手动追加
+
+SCRIPT_CONFIG_CLASSES = [v.config for v in SCRIPT_REGISTRY.values()]
+
+# type(config) → UserConfig class（替代 core/config.py 中的 isinstance 链）
+SCRIPT_USER_CONFIG_MAP: dict[type, type] = {
+    v.config: v.user_config
+    for v in SCRIPT_REGISTRY.values()
+    if v.user_config is not None
+}
+
+# ConfigBase.__name__ → 前端展示文案（原 constants.py TYPE_BOOK，现从注册表派生）
+TYPE_BOOK: dict[str, str] = {
+    v.config.__name__: v.display for v in SCRIPT_REGISTRY.values()
+}

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -66,7 +66,8 @@ from .ConfigBase import (
     ArgumentValidator,
     AdvancedArgumentValidator,
 )
-from .schema import TagItem
+# TagItem 导入已移至文件末尾（SCRIPT_REGISTRY 之后），
+# 避免与 schema.py 形成循环导入。
 
 
 def init_maaend_task_config(config) -> None:
@@ -2926,3 +2927,7 @@ SCRIPT_USER_CONFIG_MAP: dict[type, type] = {
 TYPE_BOOK: dict[str, str] = {
     v.config.__name__: v.display for v in SCRIPT_REGISTRY.values()
 }
+
+# TagItem 导入必须放在 SCRIPT_REGISTRY 之后，避免与 schema.py 形成循环导入
+# （schema.py 末尾需要 import SCRIPT_REGISTRY，而 config.py 需要 schema.py 的 TagItem）
+from .schema import TagItem

--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -20,42 +20,15 @@
 
 #   Contact: DLmaster_361@163.com
 
+from __future__ import annotations
 
 from pydantic import BaseModel, Field
 from typing import Any, Dict, List, Union, Optional, Literal
-from functools import reduce
-import types as _types
 
-from app.models.config import SCRIPT_REGISTRY as _REG
-
-# ═══════════════════════════════════════════════════════════════════════════
-# 以下类型全部从 SCRIPT_REGISTRY 自动派生，新增专项无需手动维护
-# Pydantic Schema 类名 = ConfigBase 类名（命名约定），通过 globals() 查找
-# ═══════════════════════════════════════════════════════════════════════════
-def _schema(name: str) -> type:
-    cls = globals().get(name)
-    if cls is None:
-        raise ImportError(f"schema.py 缺少 {name} 定义（需与 config.py 同名）")
-    return cls
-
-def _union(*classes: type):
-    """a | b | c ... -> UnionType（等价于 typing.Union[a, b, c]）"""
-    return reduce(_types.UnionType.__or__, classes)
-
-# config 类型名字符串
-_SCRIPT_TYPE_KEYS: tuple[str, ...] = tuple(_REG.keys())
-_SCRIPT_CONFIG_NAMES: tuple[str, ...] = tuple(v.config.__name__ for v in _REG.values())
-_USER_CONFIG_NAMES: tuple[str, ...] = tuple(
-    v.user_config.__name__ for v in _REG.values() if v.user_config is not None
-)
-
-# Pydantic Schema 类
-_SCRIPT_SCHEMAS = tuple(_schema(n) for n in _SCRIPT_CONFIG_NAMES)
-_USER_SCHEMAS = tuple(_schema(n) for n in _USER_CONFIG_NAMES)
-
-# 动态 Union 类型
-ScriptConfigUnion = _union(*_SCRIPT_SCHEMAS)
-UserConfigUnion = _union(*_USER_SCHEMAS)
+# _SCRIPT_TYPE_KEYS / _SCRIPT_CONFIG_NAMES / _USER_CONFIG_NAMES /
+# ScriptConfigUnion / UserConfigUnion 等动态类型在文件末尾定义，
+# 因为 _schema() 需要通过 globals() 按名查找 Schema 类——
+# 必须等所有 class 定义完成后才能解析。
 
 
 class OutBase(BaseModel):
@@ -1396,7 +1369,7 @@ class HistoryData(BaseModel):
 
 class ScriptCreateIn(BaseModel):
     type: Literal[_SCRIPT_TYPE_KEYS] = Field(  # type: ignore[valid-type]
-        ..., description="脚本类型"
+        ..., description="脚本类型: MAA脚本, 通用脚本, OK-WW脚本, SRC脚本, MaaEnd脚本, M9A脚本, HSR脚本"
     )
     scriptId: str | None = Field(
         default=None, description="直接从该脚本ID复制创建, 仅在复制创建时使用"
@@ -1997,3 +1970,37 @@ class WSCommandsOut(OutBase):
     """可用命令列表响应"""
 
     data: Optional[Dict[str, Any]] = Field(default=None, description="命令列表")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 以下类型全部从 SCRIPT_REGISTRY 自动派生，新增专项无需手动维护
+# 必须放在所有 Schema 类定义之后：_schema() 通过 globals() 按名查找，
+# 而 Schema 类（如 MaaConfig、GeneralConfig 等）在此之前尚未定义。
+# ═══════════════════════════════════════════════════════════════════════════
+from functools import reduce
+import operator
+
+from app.models.config import SCRIPT_REGISTRY as _REG
+
+
+def _schema(name: str) -> type:
+    cls = globals().get(name)
+    if cls is None:
+        raise ImportError(f"schema.py 缺少 {name} 定义（需与 config.py 同名）")
+    return cls
+
+
+# config 类型名字符串
+_SCRIPT_TYPE_KEYS: tuple[str, ...] = tuple(_REG.keys())
+_SCRIPT_CONFIG_NAMES: tuple[str, ...] = tuple(v.config.__name__ for v in _REG.values())
+_USER_CONFIG_NAMES: tuple[str, ...] = tuple(
+    v.user_config.__name__ for v in _REG.values() if v.user_config is not None
+)
+
+# Pydantic Schema 类（通过 globals() 按命名约定查找）
+_SCRIPT_SCHEMAS = tuple(_schema(n) for n in _SCRIPT_CONFIG_NAMES)
+_USER_SCHEMAS = tuple(_schema(n) for n in _USER_CONFIG_NAMES)
+
+# 动态 Union 类型（reduce + operator.or_ → 等价于 A | B | C | ...，公开 API）
+ScriptConfigUnion = reduce(operator.or_, _SCRIPT_SCHEMAS)
+UserConfigUnion = reduce(operator.or_, _USER_SCHEMAS)

--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -23,6 +23,39 @@
 
 from pydantic import BaseModel, Field
 from typing import Any, Dict, List, Union, Optional, Literal
+from functools import reduce
+import types as _types
+
+from app.models.config import SCRIPT_REGISTRY as _REG
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 以下类型全部从 SCRIPT_REGISTRY 自动派生，新增专项无需手动维护
+# Pydantic Schema 类名 = ConfigBase 类名（命名约定），通过 globals() 查找
+# ═══════════════════════════════════════════════════════════════════════════
+def _schema(name: str) -> type:
+    cls = globals().get(name)
+    if cls is None:
+        raise ImportError(f"schema.py 缺少 {name} 定义（需与 config.py 同名）")
+    return cls
+
+def _union(*classes: type):
+    """a | b | c ... -> UnionType（等价于 typing.Union[a, b, c]）"""
+    return reduce(_types.UnionType.__or__, classes)
+
+# config 类型名字符串
+_SCRIPT_TYPE_KEYS: tuple[str, ...] = tuple(_REG.keys())
+_SCRIPT_CONFIG_NAMES: tuple[str, ...] = tuple(v.config.__name__ for v in _REG.values())
+_USER_CONFIG_NAMES: tuple[str, ...] = tuple(
+    v.user_config.__name__ for v in _REG.values() if v.user_config is not None
+)
+
+# Pydantic Schema 类
+_SCRIPT_SCHEMAS = tuple(_schema(n) for n in _SCRIPT_CONFIG_NAMES)
+_USER_SCHEMAS = tuple(_schema(n) for n in _USER_CONFIG_NAMES)
+
+# 动态 Union 类型
+ScriptConfigUnion = _union(*_SCRIPT_SCHEMAS)
+UserConfigUnion = _union(*_USER_SCHEMAS)
 
 
 class OutBase(BaseModel):
@@ -325,30 +358,16 @@ class QueueConfig(BaseModel):
 
 class ScriptIndexItem(BaseModel):
     uid: str = Field(..., description="唯一标识符")
-    type: Literal[
-        "MaaConfig",
-        "GeneralConfig",
-        "OkwwConfig",
-        "SrcConfig",
-        "MaaEndConfig",
-        "M9AConfig",
-        "HSRConfig",
-    ] = Field(
+    type: Literal[_SCRIPT_CONFIG_NAMES] = Field(  # type: ignore[valid-type]
         ..., description="配置类型"
     )
 
 
 class UserIndexItem(BaseModel):
     uid: str = Field(..., description="唯一标识符")
-    type: Literal[
-        "MaaUserConfig",
-        "GeneralUserConfig",
-        "OkwwUserConfig",
-        "SrcUserConfig",
-        "MaaEndUserConfig",
-        "M9AUserConfig",
-        "HSRUserConfig",
-    ] = Field(..., description="配置类型")
+    type: Literal[_USER_CONFIG_NAMES] = Field(  # type: ignore[valid-type]
+        ..., description="配置类型"
+    )
 
 
 class MaaUserConfig_Info(BaseModel):
@@ -1376,8 +1395,8 @@ class HistoryData(BaseModel):
 
 
 class ScriptCreateIn(BaseModel):
-    type: Literal["MAA", "SRC", "General", "Okww", "MaaEnd", "M9A", "HSR"] = Field(
-        ..., description="脚本类型: MAA脚本, 通用脚本, OK-WW脚本, SRC脚本, MaaEnd脚本, M9A脚本, HSR脚本"
+    type: Literal[_SCRIPT_TYPE_KEYS] = Field(  # type: ignore[valid-type]
+        ..., description="脚本类型"
     )
     scriptId: str | None = Field(
         default=None, description="直接从该脚本ID复制创建, 仅在复制创建时使用"
@@ -1386,9 +1405,7 @@ class ScriptCreateIn(BaseModel):
 
 class ScriptCreateOut(OutBase):
     scriptId: str = Field(..., description="新创建的脚本ID")
-    data: Union[MaaConfig, SrcConfig, GeneralConfig, OkwwConfig, MaaEndConfig, M9AConfig, HSRConfig] = Field(
-        ..., description="脚本配置数据"
-    )
+    data: ScriptConfigUnion = Field(..., description="脚本配置数据")  # type: ignore[valid-type]
 
 
 class ScriptGetIn(BaseModel):
@@ -1399,18 +1416,14 @@ class ScriptGetIn(BaseModel):
 
 class ScriptGetOut(OutBase):
     index: List[ScriptIndexItem] = Field(..., description="脚本索引列表")
-    data: Dict[
-        str, Union[MaaConfig, SrcConfig, GeneralConfig, OkwwConfig, MaaEndConfig, M9AConfig, HSRConfig]
-    ] = Field(
+    data: Dict[str, ScriptConfigUnion] = Field(  # type: ignore[valid-type]
         ..., description="脚本数据字典, key来自于index列表的uid"
     )
 
 
 class ScriptUpdateIn(BaseModel):
     scriptId: str = Field(..., description="脚本ID")
-    data: Union[MaaConfig, SrcConfig, GeneralConfig, OkwwConfig, MaaEndConfig, M9AConfig, HSRConfig] = Field(
-        ..., description="脚本更新数据"
-    )
+    data: ScriptConfigUnion = Field(..., description="脚本更新数据")  # type: ignore[valid-type]
 
 
 class ScriptDeleteIn(BaseModel):
@@ -1456,33 +1469,14 @@ class UserGetIn(UserInBase):
 
 class UserGetOut(OutBase):
     index: List[UserIndexItem] = Field(..., description="用户索引列表")
-    data: Dict[
-        str,
-        Union[
-            MaaUserConfig,
-            SrcUserConfig,
-            GeneralUserConfig,
-            OkwwUserConfig,
-            MaaEndUserConfig,
-            M9AUserConfig,
-            HSRUserConfig,
-        ],
-    ] = Field(..., description="用户数据字典, key来自于index列表的uid")
+    data: Dict[str, UserConfigUnion] = Field(  # type: ignore[valid-type]
+        ..., description="用户数据字典, key来自于index列表的uid"
+    )
 
 
 class UserCreateOut(OutBase):
     userId: str = Field(..., description="新创建的用户ID")
-    data: Union[
-        MaaUserConfig,
-        SrcUserConfig,
-        GeneralUserConfig,
-        OkwwUserConfig,
-        MaaEndUserConfig,
-        M9AUserConfig,
-        HSRUserConfig,
-    ] = (
-        Field(..., description="用户配置数据")
-    )
+    data: UserConfigUnion = Field(..., description="用户配置数据")  # type: ignore[valid-type]
 
 
 class UserUpdateIn(UserInBase):

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -35,17 +35,7 @@ UTC4 = timezone(timedelta(hours=4))
 UTC8 = timezone(timedelta(hours=8))
 """东8区时区对象"""
 
-TYPE_BOOK = {
-    "MaaConfig": "MAA",
-    "SrcConfig": "SRC",
-    "MaaEndConfig": "MaaEnd",
-    "GeneralConfig": "通用",
-    "OkwwConfig": "ok-ww",
-    "M9AConfig": "M9A",
-    "M9AUserConfig": "M9A",
-    "HSRConfig": "HSR",
-}
-"""配置类型映射表"""
+# ── TYPE_BOOK 已迁移至 app.models.config（从 SCRIPT_REGISTRY 自动派生）──
 
 MAA_RUN_MOOD_BOOK = {"Annihilation": "剿灭", "Routine": "日常"}
 """MAA运行模式映射表"""


### PR DESCRIPTION
@
## 变更

将脚本专项的注册点从 15+ 处分散手动维护收敛为 `SCRIPT_REGISTRY` 单一真源。

### 核心改动

- **`config.py`**：新增 `_Adapter` NamedTuple + `SCRIPT_REGISTRY` 注册表，`CLASS_BOOK`、`TYPE_BOOK`、`SCRIPT_CONFIG_CLASSES`、`SCRIPT_USER_CONFIG_MAP` 全部自动派生
- **`core/config.py`**：`add_user()` 的 7 分支 `isinstance` 链 → `SCRIPT_USER_CONFIG_MAP` 单行分发
- **`core/task_manager.py`**：`isinstance` 链 → 命名约定 `XxxConfig→XxxManager` 自动匹配，Manager 类 `import` 即注册
- **`api/scripts.py`**：`SCRIPT_BOOK`/`USER_BOOK` 从 `SCRIPT_REGISTRY` + `globals()` 自动查找 Pydantic Schema 类
- **`constants.py`**：`TYPE_BOOK` 迁移至 `config.py`，从注册表派生

### 效果

| 指标 | 之前 | 之后 |
|------|------|------|
| 新增专项需改文件 | 15+ | 2 |
| 漏改风险 | 高 | 低（注册表缺项 = import 即报错） |
| 注册表条目 | 分散在 7 个文件 | 1 个 dict |

### 原理

```
SCRIPT_REGISTRY (config.py) ── 唯一真源
    │
    ├── CLASS_BOOK, TYPE_BOOK, SCRIPT_USER_CONFIG_MAP  (自动)
    ├── MultipleConfig 列表 + related_config 赋值       (自动)
    ├── SCRIPT_BOOK + USER_BOOK (api/scripts.py)        (自动)
    ├── add_user() dispatch (core/config.py)             (自动)
    └── Manager dispatch (core/task_manager.py)          (命名约定)
```
@

## Summary by Sourcery

引入 `SCRIPT_REGISTRY` 作为脚本适配器的单一可信来源，并将所有与脚本相关的注册集中到它之上。

新特性：
- 添加 `SCRIPT_REGISTRY` 及相关元数据，以从单一注册表驱动脚本配置、用户配置、管理器分发以及展示映射。

改进：
- 从 `SCRIPT_REGISTRY` 自动派生 `MultipleConfig` 脚本列表、`TYPE_BOOK` 展示映射，以及 `SCRIPT_BOOK`/`USER_BOOK` 模式映射，以减少人工维护点。
- 在核心配置和任务管理器中，用基于注册表的映射和命名约定替代基于 `isinstance` 的分发，用于脚本用户配置和管理器。
- 更新技能文档，以反映新的集中式注册流程，以及在添加新的脚本适配器时减少的接触点数量。

文档：
- 调整适配器技能文档和编码规范，将 `SCRIPT_REGISTRY` 记录为脚本注册的权威入口。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce SCRIPT_REGISTRY as the single source of truth for script adapters and centralize all script-related registrations around it.

New Features:
- Add SCRIPT_REGISTRY and related metadata to drive script config, user config, manager dispatch, and display mappings from a single registry.

Enhancements:
- Derive MultipleConfig script lists, TYPE_BOOK display mappings, and SCRIPT_BOOK/USER_BOOK schema mappings automatically from SCRIPT_REGISTRY to reduce manual maintenance points.
- Replace isinstance-based dispatch in core config and task manager with registry-driven maps and naming conventions for script user configs and managers.
- Update skill documentation to reflect the new centralized registration flow and reduced number of touchpoints when adding a new script adapter.

Documentation:
- Adjust adapter skill documentation and coding norms to document SCRIPT_REGISTRY as the authoritative registration entry for scripts.

</details>