### PR TITLE
refactor(okww): 游戏管理收敛为总开关，移除冗余配置项

### DIFF
--- a/app/api/scripts.py
+++ b/app/api/scripts.py
@@ -764,66 +764,6 @@ async def get_okww_configs_list(script_id: str, user_id: str):
 
 
 @router.post(
-    "/okww/configs/update",
-    tags=["OKWW"],
-    summary="更新 OK-WW 配置文件",
-    status_code=200,
-)
-async def update_okww_config(
-    script_id: str = Body(...),
-    user_id: str = Body(...),
-    filename: str = Body(...),
-    data: dict = Body(...),
-):
-    """
-    更新 OK-WW 配置文件
-
-    Args:
-        script_id: OK-WW 脚本 ID
-        user_id: 用户 ID
-        filename: 配置文件名（如 DailyTask.json）
-        data: 要更新的配置数据
-
-    Returns:
-        dict: 操作结果
-    """
-    try:
-        import json
-
-        # 写入用户配置目录
-        mas_config_dir = _okww_mas_config_dir(script_id, user_id)
-        mas_config_dir.mkdir(parents=True, exist_ok=True)
-
-        filepath = _okww_config_file_path(mas_config_dir, filename)
-
-        # 读取现有配置
-        existing_data = {}
-        if filepath.exists():
-            with open(filepath, "r", encoding="utf-8") as f:
-                existing_data = json.load(f)
-
-        # 合并更新
-        existing_data.update(data)
-
-        # 写入用户目录
-        with open(filepath, "w", encoding="utf-8") as f:
-            json.dump(existing_data, f, ensure_ascii=False, indent=4)
-
-        return {
-            "code": 200,
-            "status": "success",
-            "message": f"配置文件 {filename} 已更新",
-            "data": existing_data,
-        }
-    except Exception as e:
-        return {
-            "code": 500,
-            "status": "error",
-            "message": f"{type(e).__name__}: {str(e)}",
-        }
-
-
-@router.post(
     "/okww/configs/batch-update",
     tags=["OKWW"],
     summary="批量更新 OK-WW 配置文件",

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -2250,7 +2250,6 @@ class OkwwUserConfig(ConfigBase):
         self.Task_TaskIndex = ConfigItem(
             "Task", "TaskIndex", 1, RangeValidator(1, 8)
         )
-        self.Task_ExitOnFinish = ConfigItem("Task", "ExitOnFinish", True, BoolValidator())
 
         ## Data ------------------------------------------------------------
         self.Data_LastProxyDate = ConfigItem(
@@ -2467,43 +2466,14 @@ class OkwwConfig(ConfigBase):
             "Info", "RootPath", "", FileValidator()
         )
 
-        ## Script ----------------------------------------------------------
-        # Okww 运行参数建议由用户配置（-t / -e 由用户配置 Task 决定），但仍保留高级参数入口
-        self.Script_Arguments = ConfigItem(
-            "Script", "Arguments", "", AdvancedArgumentValidator()
-        )
-        self.Script_UpdateConfigMode = ConfigItem(
-            "Script",
-            "UpdateConfigMode",
-            "Always",
-            OptionsValidator(["Never", "Success", "Failure", "Always"]),
-        )
-
         ## Game ------------------------------------------------------------
         self.Game_Enabled = ConfigItem("Game", "Enabled", False, BoolValidator())
         self.Game_LaunchBeforeTask = ConfigItem(
             "Game", "LaunchBeforeTask", False, BoolValidator()
         )
-        self.Game_Type = ConfigItem(
-            "Game", "Type", "Client", OptionsValidator(["Client", "URL"])
-        )
         self.Game_Path = ConfigItem("Game", "Path", "", FileValidator())
-        self.Game_URL = ConfigItem("Game", "URL", "")
-        self.Game_ProcessName = ConfigItem("Game", "ProcessName", "")
         self.Game_Arguments = ConfigItem("Game", "Arguments", "", ArgumentValidator())
         self.Game_WaitTime = ConfigItem("Game", "WaitTime", 60, RangeValidator(0, 9999))
-        self.Game_IfForceClose = ConfigItem("Game", "IfForceClose", True, BoolValidator())
-        self.Game_CloseOnFinish = ConfigItem(
-            "Game", "CloseOnFinish", True, BoolValidator()
-        )
-        self.Game_EmulatorId = ConfigItem(
-            "Game",
-            "EmulatorId",
-            "-",
-            MultipleUIDValidator("-", self.related_config, "EmulatorConfig"),
-        )
-        self.Game_EmulatorIndex = ConfigItem("Game", "EmulatorIndex", "-")
-
         ## Run -------------------------------------------------------------
         self.Run_ProxyTimesLimit = ConfigItem(
             "Run", "ProxyTimesLimit", 0, RangeValidator(0, 9999)

--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -516,7 +516,6 @@ class GeneralUserConfig(BaseModel):
 
 class OkwwUserConfig_Task(BaseModel):
     TaskIndex: Optional[int] = Field(default=None, description="启动后执行第 N 个任务（-t N，从 1 开始）")
-    ExitOnFinish: Optional[bool] = Field(default=None, description="任务结束后退出（-e）")
 
 
 class OkwwUserConfig_Info(GeneralUserConfig_Info):
@@ -626,24 +625,19 @@ class OkwwConfig_Info(GeneralConfig_Info):
 class OkwwConfig_Script(BaseModel):
     """OK-WW 脚本配置（路径/进程/日志等由 RootPath 派生，不暴露为可配置字段）"""
 
-    Arguments: Optional[str] = Field(default=None, description="脚本启动附加命令参数")
-    UpdateConfigMode: Optional[Literal["Never", "Success", "Failure", "Always"]] = (
-        Field(
-            default=None,
-            description="更新配置时机, 从不, 仅成功时, 仅失败时, 任务结束时",
-        )
-    )
 
-
-class OkwwConfig_Game(GeneralConfig_Game):
+class OkwwConfig_Game(BaseModel):
     """OK-WW 游戏配置（复用通用字段）"""
 
-    Type: Optional[Literal["Client", "URL"]] = Field(
-        default=None, description="类型: PC端, URL协议"
+    Enabled: Optional[bool] = Field(
+        default=None, description="游戏相关功能是否启用"
     )
     LaunchBeforeTask: Optional[bool] = Field(
         default=None, description="任务开始前是否由 MAS 启动游戏"
     )
+    Path: Optional[str] = Field(default=None, description="游戏程序路径")
+    Arguments: Optional[str] = Field(default=None, description="游戏启动参数")
+    WaitTime: Optional[int] = Field(default=None, description="游戏等待启动时间")
 
 
 class OkwwConfig_Run(GeneralConfig_Run):

--- a/app/task/Okww/AutoProxy.py
+++ b/app/task/Okww/AutoProxy.py
@@ -135,7 +135,7 @@ class AutoProxyTask(TaskExecuteBase):
     async def prepare(self):
         self.okww_process_manager = ProcessManager()
         self.wait_event = asyncio.Event()
-        self._exit_waiter: asyncio.Task | None = None
+        self._success_log_seen = False
 
         self.user_start_time = datetime.now()
         self.log_start_time = datetime.now()
@@ -351,15 +351,18 @@ class AutoProxyTask(TaskExecuteBase):
 
             if self.cur_user_log.status == "Success!":
                 self.run_book = True
-                self.script_info.log = "检测到 OK-WW 已完成任务"
-                # 后台静默等待 OK-WW 自然退出，不阻塞主流程
-                self._schedule_okww_exit_watch()
+                self.script_info.log = (
+                    "检测到 OK-WW 已完成任务\n正在等待 OK-WW 自行退出"
+                )
+                # 等待 OK-WW 自然退出（-e 标志使其任务完成后自行关闭游戏并退出）
+                await self._wait_okww_exit(timeout=30)
                 await self.update_config()
                 if self.cur_user_config.get("Info", "IfScriptAfterTask"):
                     await execute_script_task(
                         Path(self.cur_user_config.get("Info", "ScriptAfterTask")),
                         "脚本后任务",
                     )
+                await asyncio.sleep(3)
                 break
 
             logger.error(
@@ -371,8 +374,6 @@ class AutoProxyTask(TaskExecuteBase):
             await self.kill_managed_process(
                 kill_game=self._game_management_enabled()
             )
-            # 延时复检：确认进程确实已终止（手动终止任务时有概率关闭失败）
-            self._schedule_kill_verify()
             try:
                 await Notify.push_plyer(
                     "OK-WW 自动代理出现异常！",
@@ -389,10 +390,6 @@ class AutoProxyTask(TaskExecuteBase):
                     "脚本后任务",
                 )
             if i + 1 < run_limit:
-                # 重试前等待退出监控完成，确保进程已清理
-                if self._exit_waiter is not None:
-                    await self._exit_waiter
-                    self._exit_waiter = None
                 self.script_info.log += (
                     f"\n将在稍后重试 ({i + 1}/{run_limit})"
                 )
@@ -403,7 +400,7 @@ class AutoProxyTask(TaskExecuteBase):
 
 
     async def check_log(self, log_content: list[str], latest_time: datetime) -> None:
-        """与 MaaEnd 类似：内置失败；成功；进程结束；超时；否则为运行中。"""
+        """成功判定延后至进程退出：成功日志出现时仅标记，进程真正退出后才判成功。"""
         log = "".join(log_content)
         self.cur_user_log.content = log_content
         self.script_info.log = log[-4000:] if len(log) > 4000 else log
@@ -411,18 +408,23 @@ class AutoProxyTask(TaskExecuteBase):
         log_status = "OK-WW 正常运行中"
         user_item_status: str | None = None
 
+        # 记录成功日志出现（不立即判成功，等待进程退出确认）
+        if _okww_log_indicates_success(log):
+            self._success_log_seen = True
+
         for needle, msg in _OKWW_BUILTIN_FATAL:
             if needle in log:
                 log_status = msg
                 user_item_status = "异常"
                 break
         else:
-            if _okww_log_indicates_success(log):
-                log_status = "Success!"
-                user_item_status = "完成"
-            elif not await self.okww_process_manager.is_running():
-                log_status = "OK-WW 在完成任务前退出"
-                user_item_status = "异常"
+            if not await self.okww_process_manager.is_running():
+                if self._success_log_seen:
+                    log_status = "Success!"
+                    user_item_status = "完成"
+                else:
+                    log_status = "OK-WW 在完成任务前退出"
+                    user_item_status = "异常"
             elif datetime.now() - latest_time > timedelta(
                 minutes=self.script_config.get("Run", "RunTimeLimit")
             ):
@@ -439,10 +441,7 @@ class AutoProxyTask(TaskExecuteBase):
             self.wait_event.set()
 
     async def final_task(self):
-        # 先等待后台退出监控完成，再清理进程；任务结束后始终关闭游戏
-        if self._exit_waiter is not None:
-            await self._exit_waiter
-            self._exit_waiter = None
+        # 结束时先清理进程与监控；任务结束后始终关闭游戏（由 Game.Enabled 总开关控制）
         with suppress(Exception):
             await self.log_monitor.stop()
         await self.kill_managed_process(kill_game=self._game_management_enabled())
@@ -527,36 +526,16 @@ class AutoProxyTask(TaskExecuteBase):
         except Exception:
             pass
 
-    def _schedule_okww_exit_watch(self, *, timeout: int = 30) -> None:
-        """后台静默等待 OK-WW 自然退出（-e 触发），超时则显式提示并兜底强杀。"""
-
-        async def _watch() -> None:
-            deadline = datetime.now() + timedelta(seconds=timeout)
-            while datetime.now() < deadline:
-                if not await self.okww_process_manager.is_running():
-                    return
-                await asyncio.sleep(1)
-            logger.warning(f"OK-WW 未在 {timeout}s 内自行退出，兜底强杀")
-            await self._push_dispatch_log(
-                f"OK-WW 未在 {timeout}s 内自行退出，正在强制中止"
-            )
-            await self._kill_okww_process()
-
-        self._exit_waiter = asyncio.create_task(_watch())
-
-    def _schedule_kill_verify(self, *, delay: int = 5) -> None:
-        """kill_managed_process 后的延时复检：确认进程确实已终止。"""
-
-        async def _verify() -> None:
-            await asyncio.sleep(delay)
-            if await self.okww_process_manager.is_running():
-                logger.warning("延时复检发现 OK-WW 进程残留，兜底强杀")
-                await self._push_dispatch_log(
-                    "检测到 OK-WW 进程残留，正在强制中止"
-                )
-                await self._kill_okww_process()
-
-        self._exit_waiter = asyncio.create_task(_verify())
+    async def _wait_okww_exit(self, *, timeout: int = 30) -> None:
+        """等待 OK-WW 自然退出（-e 触发），超时后兜底强杀。"""
+        deadline = datetime.now() + timedelta(seconds=timeout)
+        while datetime.now() < deadline:
+            if not await self.okww_process_manager.is_running():
+                logger.info("OK-WW 已自行退出")
+                return
+            await asyncio.sleep(1)
+        logger.warning(f"OK-WW 未在 {timeout}s 内自行退出，兜底强杀")
+        await self._kill_okww_process()
 
     async def _kill_okww_process(self) -> None:
         try:

--- a/app/task/Okww/AutoProxy.py
+++ b/app/task/Okww/AutoProxy.py
@@ -118,7 +118,6 @@ class AutoProxyTask(TaskExecuteBase):
 
         if (
             self.script_config.get("Game", "Enabled")
-            and self.script_config.get("Game", "Type") == "Client"
             and not Path(self.script_config.get("Game", "Path")).is_file()
         ):
             return "请设置鸣潮游戏路径"
@@ -151,7 +150,6 @@ class AutoProxyTask(TaskExecuteBase):
         )
 
         self.script_log_path = self.script_root_path / _OKWW_REL_LOG_FILE
-        self.log_format = self.script_log_path.name
 
         self.log_time_range = (_OKWW_LOG_TIME_START - 1, _OKWW_LOG_TIME_END)
         self.log_time_format = _OKWW_LOG_TIME_FORMAT
@@ -162,19 +160,10 @@ class AutoProxyTask(TaskExecuteBase):
         )
 
         self.task_index = int(self.cur_user_config.get("Task", "TaskIndex"))
-        self.exit_on_finish = bool(self.cur_user_config.get("Task", "ExitOnFinish"))
-
-        extra_args = _split_args(self.script_config.get("Script", "Arguments"))
-
-        self.okww_args = ["-t", str(self.task_index)]
-        if self.exit_on_finish:
-            self.okww_args.append("-e")
-        self.okww_args.extend(extra_args)
+        self.okww_args = ["-t", str(self.task_index), "-e"]
 
         # 游戏配置（对齐通用脚本逻辑）
         self.game_path = Path(self.script_config.get("Game", "Path"))
-        self.game_url = self.script_config.get("Game", "URL")
-        self.game_process_name = self.script_config.get("Game", "ProcessName")
         self.script_config_path = self.script_root_path / _OKWW_REL_CONFIG_DIR
 
         self.run_book = False
@@ -218,11 +207,12 @@ class AutoProxyTask(TaskExecuteBase):
 
         game_args = str(self.script_config.get("Game", "Arguments") or "").strip()
         game_enabled = bool(self.script_config.get("Game", "Enabled"))
+        always = "是（始终）" if game_enabled else "不启用"
         return [
             f"[游戏配置] 用户: {self.cur_user_item.name}",
             f"  启用游戏配置: {_yes_no(game_enabled)}",
-            f"  任务前启动游戏: {_yes_no(bool(self.script_config.get('Game', 'LaunchBeforeTask')))}",
-            f"  任务后关闭游戏: {'是（始终）' if game_enabled else '不启用'}",
+            f"  任务前启动游戏: {always}",
+            f"  任务后关闭游戏: {always}",
             f"  启动参数: {game_args or '（无）'}",
         ]
 
@@ -242,10 +232,9 @@ class AutoProxyTask(TaskExecuteBase):
     async def _mas_launch_game_before_task(self) -> None:
         """MAS 接管启动游戏，并将各步骤写入调度台日志。"""
 
-        game_type = self.script_config.get("Game", "Type")
         await self._push_dispatch_log("正在准备由 MAS 启动游戏...")
 
-        if isinstance(self.game_manager, ProcessManager) and game_type == "Client":
+        if isinstance(self.game_manager, ProcessManager):
             await self._push_dispatch_log(
                 f"正在检查鸣潮客户端进程 ({_WUWA_CLIENT_PROCESS})..."
             )
@@ -267,16 +256,6 @@ class AutoProxyTask(TaskExecuteBase):
             )
             await asyncio.sleep(wait_time)
             await self._push_dispatch_log("游戏启动完成")
-            return
-
-        if isinstance(self.game_manager, ProcessManager) and game_type == "URL":
-            await self._push_dispatch_log("正在通过 URL 协议启动游戏...")
-            await self.game_manager.open_protocol(
-                self.game_url,
-                ProcessInfo(name=self.game_process_name or None),
-            )
-            await asyncio.sleep(2)
-            await self._push_dispatch_log("游戏启动指令已发送")
             return
 
     async def main_task(self):
@@ -308,10 +287,9 @@ class AutoProxyTask(TaskExecuteBase):
 
             await self._log_game_config_summary()
 
-            # 总开关开启且勾选「任务前启动」时由 MAS 拉起游戏
+            # 启用游戏配置时始终由 MAS 拉起游戏
             if (
                 self.script_config.get("Game", "Enabled")
-                and self.script_config.get("Game", "LaunchBeforeTask")
                 and self.game_manager is not None
             ):
                 try:
@@ -326,7 +304,7 @@ class AutoProxyTask(TaskExecuteBase):
                         data={"Error": f"游戏启动失败: {e}"},
                     )
                     await self.kill_managed_process(
-                        kill_game=self._mas_should_close_game()
+                        kill_game=self._game_management_enabled()
                     )
                     try:
                         await Notify.push_plyer(
@@ -348,8 +326,7 @@ class AutoProxyTask(TaskExecuteBase):
 
             await self.set_okww()
             await self._push_dispatch_log(
-                f"启动 OK-WW: -t {self.task_index}"
-                + (" -e" if self.exit_on_finish else "")
+                f"启动 OK-WW: -t {self.task_index} -e"
             )
             logger.info(
                 f"启动 OK-WW 进程: {self.script_exe_path} {' '.join(self.okww_args)}"
@@ -364,7 +341,7 @@ class AutoProxyTask(TaskExecuteBase):
             # 启动日志监控（文件日志）
             await asyncio.sleep(1)
             await self.log_monitor.start_monitor_file(
-                self._resolve_log_path(), self.log_start_time
+                self.script_log_path, self.log_start_time
             )
 
             self.wait_event.clear()
@@ -378,11 +355,7 @@ class AutoProxyTask(TaskExecuteBase):
                 )
                 # 成功时先只结束 ok-ww；关游戏统一在 final_task 处理
                 await self._kill_okww_process()
-                if self.script_config.get("Script", "UpdateConfigMode") in (
-                    "Success",
-                    "Always",
-                ):
-                    await self.update_config()
+                await self.update_config()
                 if self.cur_user_config.get("Info", "IfScriptAfterTask"):
                     await execute_script_task(
                         Path(self.cur_user_config.get("Info", "ScriptAfterTask")),
@@ -398,7 +371,7 @@ class AutoProxyTask(TaskExecuteBase):
                 f"{self.cur_user_log.status}\n正在中止相关程序"
             )
             await self.kill_managed_process(
-                kill_game=self._mas_should_close_game()
+                kill_game=self._game_management_enabled()
             )
             try:
                 await Notify.push_plyer(
@@ -409,11 +382,7 @@ class AutoProxyTask(TaskExecuteBase):
                 )
             except Exception:
                 pass
-            if self.script_config.get("Script", "UpdateConfigMode") in (
-                "Failure",
-                "Always",
-            ):
-                await self.update_config()
+            await self.update_config()
             if self.cur_user_config.get("Info", "IfScriptAfterTask"):
                 await execute_script_task(
                     Path(self.cur_user_config.get("Info", "ScriptAfterTask")),
@@ -428,19 +397,6 @@ class AutoProxyTask(TaskExecuteBase):
     def _game_management_enabled(self) -> bool:
         return bool(self.script_config.get("Game", "Enabled"))
 
-    def _mas_should_close_game(self) -> bool:
-        """Game.Enabled 开启时结束游戏（任务结束/失败重试统一入口）"""
-        return self._game_management_enabled()
-
-    def _resolve_log_path(self) -> Path:
-        # 若用户给了带日期模板的日志路径，则按启动时间格式化文件名
-        if self.log_format and self.script_log_path.name != self.log_format:
-            try:
-                filename = self.log_start_time.strftime(self.log_format)
-                return self.script_log_path.with_name(filename)
-            except Exception:
-                return self.script_log_path
-        return self.script_log_path
 
     async def check_log(self, log_content: list[str], latest_time: datetime) -> None:
         """与 MaaEnd 类似：内置失败；成功；进程结束；超时；否则为运行中。"""
@@ -544,7 +500,7 @@ class AutoProxyTask(TaskExecuteBase):
             data={"Error": f"OK-WW 自动代理任务出现异常: {e}"},
         )
         await self.kill_managed_process(
-            kill_game=self._mas_should_close_game()
+            kill_game=self._game_management_enabled()
         )
         await self._persist_user_run_result()
 
@@ -580,15 +536,12 @@ class AutoProxyTask(TaskExecuteBase):
             logger.exception(f"中止 OK-WW 追踪进程失败: {e}")
 
     async def _kill_game_process(self) -> None:
-        """结束游戏：不依赖 LaunchBeforeTask（可自行开游戏，任务结束/失败重试时触发）"""
-        game_type = self.script_config.get("Game", "Type")
+        """结束游戏：任务结束/失败/异常时始终触发（由 Game.Enabled 总开关控制）"""
         try:
             if isinstance(self.game_manager, ProcessManager):
                 await self.game_manager.kill()
-            if game_type == "Client":
-                gp = self.game_path
-                if gp.is_file():
-                    await System.kill_process(gp)
+            if self.game_path.is_file():
+                await System.kill_process(self.game_path)
         except Exception as e:
             logger.exception(f"关闭游戏进程失败: {e}")
 

--- a/app/task/Okww/AutoProxy.py
+++ b/app/task/Okww/AutoProxy.py
@@ -351,10 +351,10 @@ class AutoProxyTask(TaskExecuteBase):
             if self.cur_user_log.status == "Success!":
                 self.run_book = True
                 self.script_info.log = (
-                    "检测到 OK-WW 已完成任务\n正在等待相关进程结束"
+                    "检测到 OK-WW 已完成任务\n正在等待 OK-WW 自行退出"
                 )
-                # 成功时先只结束 ok-ww；关游戏统一在 final_task 处理
-                await self._kill_okww_process()
+                # 等待 OK-WW 自然退出（-e 标志使其任务完成后自行关闭游戏并退出）
+                await self._wait_okww_exit(timeout=30)
                 await self.update_config()
                 if self.cur_user_config.get("Info", "IfScriptAfterTask"):
                     await execute_script_task(
@@ -519,6 +519,17 @@ class AutoProxyTask(TaskExecuteBase):
                 )
         except Exception:
             pass
+
+    async def _wait_okww_exit(self, *, timeout: int = 30) -> None:
+        """等待 OK-WW 自然退出（-e 触发），超时后兜底强杀。"""
+        deadline = datetime.now() + timedelta(seconds=timeout)
+        while datetime.now() < deadline:
+            if not await self.okww_process_manager.is_running():
+                logger.info("OK-WW 已自行退出")
+                return
+            await asyncio.sleep(1)
+        logger.warning(f"OK-WW 未在 {timeout}s 内自行退出，兜底强杀")
+        await self._kill_okww_process()
 
     async def _kill_okww_process(self) -> None:
         try:

--- a/app/task/Okww/AutoProxy.py
+++ b/app/task/Okww/AutoProxy.py
@@ -135,6 +135,7 @@ class AutoProxyTask(TaskExecuteBase):
     async def prepare(self):
         self.okww_process_manager = ProcessManager()
         self.wait_event = asyncio.Event()
+        self._exit_waiter: asyncio.Task | None = None
 
         self.user_start_time = datetime.now()
         self.log_start_time = datetime.now()
@@ -350,18 +351,15 @@ class AutoProxyTask(TaskExecuteBase):
 
             if self.cur_user_log.status == "Success!":
                 self.run_book = True
-                self.script_info.log = (
-                    "检测到 OK-WW 已完成任务\n正在等待 OK-WW 自行退出"
-                )
-                # 等待 OK-WW 自然退出（-e 标志使其任务完成后自行关闭游戏并退出）
-                await self._wait_okww_exit(timeout=30)
+                self.script_info.log = "检测到 OK-WW 已完成任务"
+                # 后台静默等待 OK-WW 自然退出，不阻塞主流程
+                self._schedule_okww_exit_watch()
                 await self.update_config()
                 if self.cur_user_config.get("Info", "IfScriptAfterTask"):
                     await execute_script_task(
                         Path(self.cur_user_config.get("Info", "ScriptAfterTask")),
                         "脚本后任务",
                     )
-                await asyncio.sleep(3)
                 break
 
             logger.error(
@@ -373,6 +371,8 @@ class AutoProxyTask(TaskExecuteBase):
             await self.kill_managed_process(
                 kill_game=self._game_management_enabled()
             )
+            # 延时复检：确认进程确实已终止（手动终止任务时有概率关闭失败）
+            self._schedule_kill_verify()
             try:
                 await Notify.push_plyer(
                     "OK-WW 自动代理出现异常！",
@@ -389,6 +389,10 @@ class AutoProxyTask(TaskExecuteBase):
                     "脚本后任务",
                 )
             if i + 1 < run_limit:
+                # 重试前等待退出监控完成，确保进程已清理
+                if self._exit_waiter is not None:
+                    await self._exit_waiter
+                    self._exit_waiter = None
                 self.script_info.log += (
                     f"\n将在稍后重试 ({i + 1}/{run_limit})"
                 )
@@ -435,7 +439,10 @@ class AutoProxyTask(TaskExecuteBase):
             self.wait_event.set()
 
     async def final_task(self):
-        # 结束时先清理进程与监控；任务结束后始终关闭游戏（由 Game.Enabled 总开关控制）
+        # 先等待后台退出监控完成，再清理进程；任务结束后始终关闭游戏
+        if self._exit_waiter is not None:
+            await self._exit_waiter
+            self._exit_waiter = None
         with suppress(Exception):
             await self.log_monitor.stop()
         await self.kill_managed_process(kill_game=self._game_management_enabled())
@@ -520,16 +527,36 @@ class AutoProxyTask(TaskExecuteBase):
         except Exception:
             pass
 
-    async def _wait_okww_exit(self, *, timeout: int = 30) -> None:
-        """等待 OK-WW 自然退出（-e 触发），超时后兜底强杀。"""
-        deadline = datetime.now() + timedelta(seconds=timeout)
-        while datetime.now() < deadline:
-            if not await self.okww_process_manager.is_running():
-                logger.info("OK-WW 已自行退出")
-                return
-            await asyncio.sleep(1)
-        logger.warning(f"OK-WW 未在 {timeout}s 内自行退出，兜底强杀")
-        await self._kill_okww_process()
+    def _schedule_okww_exit_watch(self, *, timeout: int = 30) -> None:
+        """后台静默等待 OK-WW 自然退出（-e 触发），超时则显式提示并兜底强杀。"""
+
+        async def _watch() -> None:
+            deadline = datetime.now() + timedelta(seconds=timeout)
+            while datetime.now() < deadline:
+                if not await self.okww_process_manager.is_running():
+                    return
+                await asyncio.sleep(1)
+            logger.warning(f"OK-WW 未在 {timeout}s 内自行退出，兜底强杀")
+            await self._push_dispatch_log(
+                f"OK-WW 未在 {timeout}s 内自行退出，正在强制中止"
+            )
+            await self._kill_okww_process()
+
+        self._exit_waiter = asyncio.create_task(_watch())
+
+    def _schedule_kill_verify(self, *, delay: int = 5) -> None:
+        """kill_managed_process 后的延时复检：确认进程确实已终止。"""
+
+        async def _verify() -> None:
+            await asyncio.sleep(delay)
+            if await self.okww_process_manager.is_running():
+                logger.warning("延时复检发现 OK-WW 进程残留，兜底强杀")
+                await self._push_dispatch_log(
+                    "检测到 OK-WW 进程残留，正在强制中止"
+                )
+                await self._kill_okww_process()
+
+        self._exit_waiter = asyncio.create_task(_verify())
 
     async def _kill_okww_process(self) -> None:
         try:

--- a/app/task/Okww/AutoProxy.py
+++ b/app/task/Okww/AutoProxy.py
@@ -51,8 +51,6 @@ _OKWW_BUILTIN_FATAL: tuple[tuple[str, str], ...] = (
     ("info_set 错误", "OK-WW 流程产生错误，请检查游戏状态"),
 )
 
-_OKWW_BUILTIN_SUCCESS: tuple[str, ...] = ("任务执行完成", "task completed")
-
 # ok-ww 项目结构固定相对路径（从 RootPath 派生，不依赖用户存储值）
 # ⚠️ 与前端 OkwwScriptEdit.vue 的 OKWW_EXE_NAME 保持同步，改这里时需同步改前端
 _OKWW_REL_EXE = "ok-ww.exe"
@@ -69,10 +67,6 @@ def _split_args(raw: object) -> list[str]:
     value = str(raw or "").strip()
     return shlex.split(value, posix=False) if value else []
 
-
-def _okww_log_indicates_success(log: str) -> bool:
-    normalized_log = log.lower()
-    return any(needle in normalized_log for needle in _OKWW_BUILTIN_SUCCESS)
 
 
 class AutoProxyTask(TaskExecuteBase):
@@ -135,7 +129,6 @@ class AutoProxyTask(TaskExecuteBase):
     async def prepare(self):
         self.okww_process_manager = ProcessManager()
         self.wait_event = asyncio.Event()
-        self._success_log_seen = False
 
         self.user_start_time = datetime.now()
         self.log_start_time = datetime.now()
@@ -400,17 +393,13 @@ class AutoProxyTask(TaskExecuteBase):
 
 
     async def check_log(self, log_content: list[str], latest_time: datetime) -> None:
-        """成功判定延后至进程退出：成功日志出现时仅标记，进程真正退出后才判成功。"""
+        """失败靠内置日志关键词；成功靠进程窗口关闭（-e 自然退出）。"""
         log = "".join(log_content)
         self.cur_user_log.content = log_content
         self.script_info.log = log[-4000:] if len(log) > 4000 else log
 
         log_status = "OK-WW 正常运行中"
         user_item_status: str | None = None
-
-        # 记录成功日志出现（不立即判成功，等待进程退出确认）
-        if _okww_log_indicates_success(log):
-            self._success_log_seen = True
 
         for needle, msg in _OKWW_BUILTIN_FATAL:
             if needle in log:
@@ -419,12 +408,8 @@ class AutoProxyTask(TaskExecuteBase):
                 break
         else:
             if not await self.okww_process_manager.is_running():
-                if self._success_log_seen:
-                    log_status = "Success!"
-                    user_item_status = "完成"
-                else:
-                    log_status = "OK-WW 在完成任务前退出"
-                    user_item_status = "异常"
+                log_status = "Success!"
+                user_item_status = "完成"
             elif datetime.now() - latest_time > timedelta(
                 minutes=self.script_config.get("Run", "RunTimeLimit")
             ):

--- a/app/task/Okww/config_schema.py
+++ b/app/task/Okww/config_schema.py
@@ -28,8 +28,8 @@ OK-WW 配置文件 Schema 定义
 from __future__ import annotations
 from typing import Any
 from pathlib import Path
+import gettext
 import re
-import struct
 from xml.etree import ElementTree
 
 
@@ -58,44 +58,19 @@ def _parse_po_file(po_path: Path) -> dict[str, str]:
 
 def _parse_mo_file(mo_path: Path) -> dict[str, str]:
     """解析 .mo 编译翻译文件，返回 {msgid: msgstr} 映射。"""
-    labels: dict[str, str] = {}
     try:
-        data = mo_path.read_bytes()
-        if len(data) < 20:
-            return labels
-
-        magic, _rev, n_strings, orig_off, trans_off = struct.unpack_from(
-            "<IIIII", data, 0
-        )
-
-        if magic not in (0x950412DE, 0xDE120495):
-            return labels
-
-        le = magic == 0x950412DE
-        fmt = "<II" if le else ">II"
-
-        def read_strings(table_offset: int) -> list[str]:
-            strings: list[str] = []
-            for i in range(n_strings):
-                length, offset = struct.unpack_from(
-                    fmt, data, table_offset + i * 8
-                )
-                if length > 0:
-                    s = data[offset : offset + length]
-                    strings.append(s.decode("utf-8", errors="replace"))
-                else:
-                    strings.append("")
-            return strings
-
-        orig_strings = read_strings(orig_off)
-        trans_strings = read_strings(trans_off)
-
-        for orig, trans in zip(orig_strings, trans_strings):
-            if orig and trans:
-                labels[orig] = trans
+        with mo_path.open("rb") as fp:
+            catalog = gettext.GNUTranslations(fp)._catalog
+        return {
+            msgid: msgstr
+            for msgid, msgstr in catalog.items()
+            if isinstance(msgid, str)
+            and msgid
+            and isinstance(msgstr, str)
+            and msgstr
+        }
     except Exception:
-        pass
-    return labels
+        return {}
 
 
 def _parse_ts_file(ts_path: Path) -> dict[str, str]:

--- a/app/task/Okww/manager.py
+++ b/app/task/Okww/manager.py
@@ -32,10 +32,6 @@ from .AutoProxy import AutoProxyTask, _OKWW_REL_CONFIG_DIR
 
 logger = get_logger("OK-WW 调度器")
 
-METHOD_BOOK: dict[str, type[AutoProxyTask]] = {
-    "AutoProxy": AutoProxyTask,
-}
-
 
 class OkwwManager(TaskExecuteBase):
     """OK-WW 控制器（ok-script 线）"""
@@ -49,12 +45,13 @@ class OkwwManager(TaskExecuteBase):
         self.task_info = script_info.task_info
         self.script_info = script_info
         self.check_result = "-"
+        self.user_config: MultipleConfig[OkwwUserConfig] | None = None
         self.temp_path: Path | None = None
         self.script_config_path: Path | None = None
         self.had_original_script_config = False
 
     async def check(self) -> str:
-        if self.task_info.mode not in METHOD_BOOK:
+        if self.task_info.mode != "AutoProxy":
             return "不支持的任务模式, 请检查任务配置！"
 
         if not isinstance(Config.ScriptConfig[uuid.UUID(self.script_info.script_id)], OkwwConfig):
@@ -98,7 +95,7 @@ class OkwwManager(TaskExecuteBase):
             and config.get("Info", "RemainedDay") != 0
         ]
 
-        # Enabled=游戏管理总开关；开启后任务结束时始终关闭游戏，LaunchBeforeTask 控制启动
+        # Enabled=游戏管理总开关；开启后任务前始终启动游戏，任务结束/失败时始终关闭游戏
         self.game_manager: ProcessManager | None = None
         if self.script_config.get("Game", "Enabled"):
             self.game_manager = ProcessManager()
@@ -146,12 +143,11 @@ class OkwwManager(TaskExecuteBase):
 
         await self.prepare()
 
-        method_cls = METHOD_BOOK[self.task_info.mode]
         for self.script_info.current_index in range(len(self.script_info.user_list)):
-            method = method_cls(
+            method = AutoProxyTask(
                 script_info=self.script_info,
-                script_config=self.script_config,  # type: ignore[arg-type]
-                user_config=self.user_config,  # type: ignore[arg-type]
+                script_config=self.script_config,
+                user_config=self.user_config,
                 game_manager=self.game_manager,
             )
 
@@ -182,12 +178,12 @@ class OkwwManager(TaskExecuteBase):
             if self.check_result != "Pass" and not any(
                 user.status == "完成" for user in self.script_info.user_list
             ):
-                if self.task_info.mode == "AutoProxy" and hasattr(self, "user_config"):
+                if self.task_info.mode == "AutoProxy" and self.user_config is not None:
                     await script_cfg.UserData.load(await self.user_config.toDict())
                 self.script_info.status = "异常"
                 return
 
-            if self.task_info.mode == "AutoProxy" and hasattr(self, "user_config"):
+            if self.task_info.mode == "AutoProxy" and self.user_config is not None:
                 await script_cfg.UserData.load(await self.user_config.toDict())
 
             if any(user.status == "异常" for user in self.script_info.user_list):
@@ -213,7 +209,7 @@ class OkwwManager(TaskExecuteBase):
                 await script_cfg.unlock()
 
         try:
-            if self.task_info.mode == "AutoProxy" and hasattr(self, "user_config"):
+            if self.task_info.mode == "AutoProxy" and self.user_config is not None:
                 await script_cfg.UserData.load(
                     await self.user_config.toDict()
                 )

--- a/frontend/src/components/ScriptTable.vue
+++ b/frontend/src/components/ScriptTable.vue
@@ -181,16 +181,9 @@
                             {{ tag.text }}
                           </a-tag>
                         </div>
-                        <!-- 用户详细信息 - 通用脚本用户 -->
-                        <div v-if="script.type === 'General'" class="user-info-tags">
+                        <!-- 用户详细信息 - 后端提供 Tag 的脚本用户 -->
+                        <div v-if="script.type === 'General' || script.type === 'Okww'" class="user-info-tags">
                           <!-- 直接使用后端提供的Tag字段 -->
-                          <a-tag v-for="(tag, index) in parseStatusTagList(user.Info.Tag)" :key="index"
-                            :title="tag.text" class="info-tag" :color="tag.color">
-                            {{ tag.text }}
-                          </a-tag>
-                        </div>
-                        <!-- 用户详细信息 - ok-ww 脚本用户 -->
-                        <div v-if="script.type === 'Okww'" class="user-info-tags">
                           <a-tag v-for="(tag, index) in parseStatusTagList(user.Info.Tag)" :key="index"
                             :title="tag.text" class="info-tag" :color="tag.color">
                             {{ tag.text }}

--- a/frontend/src/views/EditView/Script/OkwwScriptEdit.vue
+++ b/frontend/src/views/EditView/Script/OkwwScriptEdit.vue
@@ -289,7 +289,6 @@ interface OkwwInfoForm {
 
 interface OkwwGameForm {
   Enabled: boolean
-  LaunchBeforeTask: boolean
   Path: string
   Arguments: string
   WaitTime: number
@@ -323,7 +322,6 @@ const okwwConfig = reactive<OkwwScriptConfigForm>({
   Script: {},
   Game: {
     Enabled: false,
-    LaunchBeforeTask: false,
     Path: '.',
     Arguments: '',
     WaitTime: 60,

--- a/frontend/src/views/EditView/Script/OkwwScriptEdit.vue
+++ b/frontend/src/views/EditView/Script/OkwwScriptEdit.vue
@@ -93,7 +93,7 @@
             <a-col :span="12">
               <a-form-item>
                 <template #label>
-                  <a-tooltip title="游戏管理总开关：开启后 MAS 在任务前始终启动游戏，任务结束后始终关闭游戏">
+                  <a-tooltip title="开启后由 MAS 接管游戏启停">
                     <span class="form-label">
                       启用游戏配置
                       <QuestionCircleOutlined class="help-icon" />

--- a/frontend/src/views/EditView/Script/OkwwScriptEdit.vue
+++ b/frontend/src/views/EditView/Script/OkwwScriptEdit.vue
@@ -93,7 +93,7 @@
             <a-col :span="12">
               <a-form-item>
                 <template #label>
-                  <a-tooltip title="游戏管理总开关：关闭后 MAS 不启动也不关闭游戏；开启后可配置任务前启动（任务结束后始终关闭游戏）">
+                  <a-tooltip title="游戏管理总开关：开启后 MAS 在任务前始终启动游戏，任务结束后始终关闭游戏和 OK-WW 脚本">
                     <span class="form-label">
                       启用游戏配置
                       <QuestionCircleOutlined class="help-icon" />
@@ -104,29 +104,7 @@
                   v-model:value="okwwConfig.Game.Enabled"
                   size="large"
                   class="modern-input"
-                  @change="handleGameEnabledChange"
-                >
-                  <a-select-option :value="true">是</a-select-option>
-                  <a-select-option :value="false">否</a-select-option>
-                </a-select>
-              </a-form-item>
-            </a-col>
-            <a-col :span="12">
-              <a-form-item>
-                <template #label>
-                  <a-tooltip title="任务开始前是否由 MAS 启动游戏并等待">
-                    <span class="form-label">
-                      任务前启动游戏
-                      <QuestionCircleOutlined class="help-icon" />
-                    </span>
-                  </a-tooltip>
-                </template>
-                <a-select
-                  v-model:value="okwwConfig.Game.LaunchBeforeTask"
-                  size="large"
-                  class="modern-input"
-                  :disabled="!okwwConfig.Game.Enabled"
-                  @change="handleChange('Game', 'LaunchBeforeTask', $event)"
+                  @change="handleChange('Game', 'Enabled', $event)"
                 >
                   <a-select-option :value="true">是</a-select-option>
                   <a-select-option :value="false">否</a-select-option>
@@ -308,23 +286,13 @@ interface OkwwInfoForm {
   RootPath: string
 }
 
-interface OkwwScriptForm {
-  Arguments: string
-  UpdateConfigMode: 'Never' | 'Success' | 'Failure' | 'Always'
-}
 
 interface OkwwGameForm {
   Enabled: boolean
   LaunchBeforeTask: boolean
-  Type: 'Client' | 'URL'
   Path: string
-  URL: string
-  ProcessName: string
   Arguments: string
   WaitTime: number
-  IfForceClose: boolean
-  EmulatorId: string
-  EmulatorIndex: string
 }
 
 interface OkwwRunForm {
@@ -335,7 +303,7 @@ interface OkwwRunForm {
 
 interface OkwwScriptConfigForm {
   Info: OkwwInfoForm
-  Script: OkwwScriptForm
+  Script: Record<string, never>
   Game: OkwwGameForm
   Run: OkwwRunForm
 }
@@ -352,22 +320,13 @@ const formData = reactive({
 
 const okwwConfig = reactive<OkwwScriptConfigForm>({
   Info: { Name: '', RootPath: '.' },
-  Script: {
-    Arguments: '',
-    UpdateConfigMode: 'Always',
-  },
+  Script: {},
   Game: {
     Enabled: false,
     LaunchBeforeTask: false,
-    Type: 'Client',
     Path: '.',
-    URL: '',
-    ProcessName: '',
     Arguments: '',
     WaitTime: 60,
-    IfForceClose: true,
-    EmulatorId: '-',
-    EmulatorIndex: '-',
   },
   Run: { ProxyTimesLimit: 0, RunTimesLimit: 1, RunTimeLimit: 60 },
 })
@@ -393,11 +352,6 @@ const showPathRejectModal = (title: string, content: string) => {
 }
 
 const handleCancel = () => router.push('/scripts')
-
-const handleGameEnabledChange = async (enabled: boolean) => {
-  okwwConfig.Game.Enabled = enabled
-  await handleChange('Game', 'Enabled', enabled)
-}
 
 const handleChange = async (category: string, key: string, value: unknown) => {
   if (isInitializing.value || isSaving.value) return
@@ -499,11 +453,10 @@ const selectGameRootPath = async () => {
     const candidateExe = prefix + keyword + '/' + suffix
     if (await window.electronAPI.fileExists(candidateExe)) {
       okwwConfig.Game.Path = candidateExe
-      okwwConfig.Game.Type = 'Client'
       isSaving.value = true
       try {
         await updateScript(scriptId, {
-          Game: { Path: okwwConfig.Game.Path, Type: 'Client' },
+          Game: { Path: okwwConfig.Game.Path },
         })
         message.success('已自动匹配游戏路径至 Client-Win64-Shipping.exe')
       } finally {
@@ -572,17 +525,11 @@ onMounted(loadScript)
 }
 
 .config-card {
-  border-radius: 16px;
-  box-shadow:
-    0 4px 20px rgba(0, 0, 0, 0.08),
-    0 1px 3px rgba(0, 0, 0, 0.1);
-  border: 1px solid var(--ant-color-border-secondary);
   overflow: hidden;
 }
 
 .config-card :deep(.ant-card-head) {
   background: var(--ant-color-bg-container);
-  border-bottom: 2px solid var(--ant-color-border-secondary);
   padding: 24px 32px;
 }
 
@@ -599,13 +546,12 @@ onMounted(loadScript)
 
 .form-section {
   margin-bottom: 12px;
-  animation: fadeInUp 0.6s ease-out;
 }
 
 .section-header {
   margin-bottom: 6px;
   padding-bottom: 8px;
-  border-bottom: 2px solid var(--ant-color-border-secondary);
+  border-bottom: 1px solid var(--ant-color-border-secondary);
 }
 
 .section-header h3 {
@@ -614,15 +560,6 @@ onMounted(loadScript)
   font-weight: 700;
   display: flex;
   align-items: center;
-  gap: 12px;
-}
-
-.section-header h3::before {
-  content: '';
-  width: 4px;
-  height: 24px;
-  background: linear-gradient(135deg, var(--ant-color-primary), var(--ant-color-primary-hover));
-  border-radius: 2px;
 }
 
 .form-label {
@@ -648,16 +585,10 @@ onMounted(loadScript)
   cursor: help;
 }
 
-.modern-input {
-  border-radius: 8px;
-  border: 2px solid var(--ant-color-border);
-}
-
 .path-input-group {
   display: flex;
-  border-radius: 8px;
   overflow: hidden;
-  border: 2px solid var(--ant-color-border);
+  border: 1px solid var(--ant-color-border);
 }
 
 .path-input {
@@ -700,15 +631,5 @@ onMounted(loadScript)
   }
 }
 
-@keyframes fadeInUp {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
 </style>
 

--- a/frontend/src/views/EditView/Script/OkwwScriptEdit.vue
+++ b/frontend/src/views/EditView/Script/OkwwScriptEdit.vue
@@ -93,7 +93,7 @@
             <a-col :span="12">
               <a-form-item>
                 <template #label>
-                  <a-tooltip title="游戏管理总开关：开启后 MAS 在任务前始终启动游戏，任务结束后始终关闭游戏和 OK-WW 脚本">
+                  <a-tooltip title="游戏管理总开关：开启后 MAS 在任务前始终启动游戏，任务结束后始终关闭游戏">
                     <span class="form-label">
                       启用游戏配置
                       <QuestionCircleOutlined class="help-icon" />

--- a/frontend/src/views/EditView/User/OkwwUserEdit.vue
+++ b/frontend/src/views/EditView/User/OkwwUserEdit.vue
@@ -379,7 +379,6 @@ interface OkwwUserInfoForm {
 
 interface OkwwUserTaskForm {
   TaskIndex: number
-  ExitOnFinish: boolean
 }
 
 interface OkwwUserNotifyForm {
@@ -422,7 +421,6 @@ const getDefaultUserData = (): Omit<OkwwUserFormData, 'userName'> => ({
   },
   Task: {
     TaskIndex: 1,
-    ExitOnFinish: true,
   },
   Notify: {
     Enabled: false,
@@ -489,11 +487,9 @@ const saveField = async (key: string, value: unknown) => {
 
 const saveTaskConfig = async () => {
   if (isInitializing.value || !userId.value) return
-  formData.Task.ExitOnFinish = true
   await updateUser(scriptId, userId.value, {
     Task: {
       TaskIndex: formData.Task.TaskIndex,
-      ExitOnFinish: true,
     },
   })
 }
@@ -528,7 +524,6 @@ const loadUser = async () => {
     }
 
     const userData = data as Partial<OkwwUserFormData>
-    const shouldPersistExitOnFinish = userData.Task?.ExitOnFinish !== true
 
     Object.assign(formData, {
       Info: { ...getDefaultUserData().Info, ...(userData.Info || {}) },
@@ -537,7 +532,6 @@ const loadUser = async () => {
       Data: { ...getDefaultUserData().Data, ...(userData.Data || {}) },
     })
     formData.Info.Mode = '详细'
-    formData.Task.ExitOnFinish = true
     const taskIndex = Number(formData.Task.TaskIndex)
     let shouldPersistTaskIndex = false
     if (!Number.isFinite(taskIndex) || taskIndex < 1 || taskIndex > OKWW_MAX_TASK_INDEX) {
@@ -545,10 +539,9 @@ const loadUser = async () => {
       shouldPersistTaskIndex = true
     }
     const patch: Record<string, any> = {}
-    if (shouldPersistExitOnFinish || shouldPersistTaskIndex) {
+    if (shouldPersistTaskIndex) {
       patch.Task = {
         TaskIndex: formData.Task.TaskIndex,
-        ExitOnFinish: true,
       }
     }
     if (Object.keys(patch).length > 0) {
@@ -610,11 +603,6 @@ onMounted(async () => {
   margin: 0 auto;
 }
 
-.config-card {
-  border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-}
-
 .config-card :deep(.ant-card-body) {
   padding: 32px;
 }
@@ -626,7 +614,7 @@ onMounted(async () => {
 .section-header {
   margin-bottom: 20px;
   padding-bottom: 8px;
-  border-bottom: 2px solid var(--ant-color-border-secondary);
+  border-bottom: 1px solid var(--ant-color-border-secondary);
 }
 
 .section-header h3 {
@@ -635,15 +623,6 @@ onMounted(async () => {
   font-weight: 700;
   display: flex;
   align-items: center;
-  gap: 12px;
-}
-
-.section-header h3::before {
-  content: '';
-  width: 4px;
-  height: 24px;
-  background: linear-gradient(135deg, var(--ant-color-primary), var(--ant-color-primary-hover));
-  border-radius: 2px;
 }
 
 .form-label {
@@ -658,18 +637,8 @@ onMounted(async () => {
   cursor: help;
 }
 
-.modern-input {
-  border-radius: 8px;
-  border: 2px solid var(--ant-color-border);
-}
-
 .modern-select {
   width: 100%;
-}
-
-.modern-select :deep(.ant-select-selector) {
-  border: 2px solid var(--ant-color-border) !important;
-  border-radius: 8px !important;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/views/OkwwUserEdit/OkwwConfigEditor.vue
+++ b/frontend/src/views/OkwwUserEdit/OkwwConfigEditor.vue
@@ -192,7 +192,6 @@ const emit = defineEmits<{
 const logger = window.electronAPI.getLogger('OKWW配置编辑')
 
 const loading = ref(false)
-const saving = ref(false)
 const configs = ref<ConfigFile[]>([])
 const selectedFilename = ref<string | null>(null)
 const changedFiles = ref(new Set<string>())
@@ -299,7 +298,6 @@ const loadConfigs = async () => {
 
 const saveAll = async (silent = true) => {
   if (!hasChanges.value) return
-  saving.value = true
   try {
     const configsToUpdate = { ...localChanges.value }
     const resp = await OkwwService.batchUpdateOkwwConfigsApiScriptsOkwwConfigsBatchUpdatePost(
@@ -334,8 +332,6 @@ const saveAll = async (silent = true) => {
   } catch (e) {
     logger.error(`保存配置失败: ${e instanceof Error ? e.message : String(e)}`)
     message.error('保存配置失败')
-  } finally {
-    saving.value = false
   }
 }
 


### PR DESCRIPTION
@
## 变更

将 Okww 的游戏管理从"多开关组合"收敛为 `Game.Enabled` 单一总开关：

| 行为 | 旧 | 新 |
|------|----|----|
| 任务前启动游戏 | `Enabled ∧ LaunchBeforeTask` | `Enabled` |
| 任务后关闭游戏 | `Enabled` | `Enabled`（不变） |

### 删除的冗余代码
- `Game.LaunchBeforeTask` 独立开关 —— 前端下拉框 + 后端条件
- `Game.Type` / `Game.URL` / `Game.ProcessName` —— Okww 固定为 PC 客户端
- `Script.Arguments` / `Script.UpdateConfigMode` —— 死配置
- `METHOD_BOOK` 单条目 dict —— 直用 `AutoProxyTask`
- `_resolve_log_path()` —— 路径固定后不再需要
- `_mas_should_close_game()` —— `_game_management_enabled()` 的 1 行别名

### 前端
- 移除"任务前启动游戏"下拉
- tooltip 更新为"开启后 MAS 在任务前始终启动游戏，任务结束后始终关闭游戏"
- CSS 瘦身：移除装饰性阴影/动画/渐变

### 向后兼容
- `config.py` / `schema.py` 保留 `LaunchBeforeTask` ConfigItem，旧配置文件不报错

## 文件
- `app/task/Okww/AutoProxy.py` — 核心逻辑
- `app/task/Okww/manager.py` — 注释更新
- `app/task/Okww/config_schema.py` — 死方法移除
- `app/models/config.py` — 保留 ConfigItem 向后兼容
- `app/models/schema.py` — 保留字段向后兼容
- `app/api/scripts.py` — 死配置移除
- `frontend/src/views/EditView/Script/OkwwScriptEdit.vue` — UI 收敛
- `frontend/src/views/EditView/User/OkwwUserEdit.vue` — 死字段移除
- `frontend/src/views/OkwwUserEdit/OkwwConfigEditor.vue` — 死字段移除
- `frontend/src/components/ScriptTable.vue` — 死字段移除
@