### PR TITLE
fix: WS 断联时后端不再自杀，休眠恢复后自动重连

### DIFF
--- a/app/api/core.py
+++ b/app/api/core.py
@@ -21,7 +21,6 @@
 #   Contact: DLmaster_361@163.com
 
 
-import os
 import time
 import asyncio
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
@@ -34,13 +33,6 @@ from app.utils import get_logger
 
 router = APIRouter(prefix="/api/core", tags=["核心信息"])
 logger = get_logger("DEV")
-
-
-def is_backend_dev_mode() -> bool:
-    """判断后端是否处于开发模式。"""
-
-    raw = str(os.getenv("AUTO_MAS_DEV", "")).strip().lower()
-    return raw in {"1", "true", "yes", "on"}
 
 
 @router.websocket("/ws")
@@ -90,10 +82,10 @@ async def connect_websocket(websocket: WebSocket):
             break
 
     Config.websocket = None
-    if is_backend_dev_mode():
-        logger.warning("后端开发模式下检测到 WS 断链，跳过 KillSelf 自动退出")
-    else:
-        await System.set_power("KillSelf", from_frontend=True)
+    # ponytail: 不因 WS 断联自动 KillSelf。
+    # 机器休眠/网络抖动导致的断联不应杀死后端。
+    # 前端关闭时通过 /api/core/close 显式退出，Electron before-quit 也会 taskkill 兜底。
+    logger.info("WebSocket 连接已断开，等待前端重连...")
 
 
 @ws_command("core.close")

--- a/frontend/src/composables/useWebSocket.ts
+++ b/frontend/src/composables/useWebSocket.ts
@@ -3,6 +3,7 @@ import { ref, type Ref } from 'vue'
 import schedulerHandlers from '@/views/scheduler/schedulerHandlers'
 import { Modal } from 'ant-design-vue'
 import { useAppClosing } from '@/composables/useAppClosing'
+import { beginBootstrap, markAsInitialized } from '@/composables/useAppInitialization'
 const logger = window.electronAPI.getLogger('WebSocket连接')
 
 // ====== 配置项 ======
@@ -965,9 +966,11 @@ const createGlobalWebSocket = (): WebSocket => {
       logger.warn('尝试创建新连接但当前连接仍有效，直接返回现有连接')
       return global.wsRef
     }
+    // ponytail: 休眠后 Chromium WS 可能卡在 CONNECTING，关闭重建
     if (global.wsRef.readyState === WebSocket.CONNECTING) {
-      logger.warn('尝试创建新连接但当前连接正在建立中，直接返回现有连接')
-      return global.wsRef
+      logger.warn('旧连接卡在 CONNECTING 状态，强制关闭并重建')
+      try { global.wsRef.close() } catch (_) {}
+      global.wsRef = null
     }
     // 清理已关闭或错误状态的连接
     logger.info(`清理旧的WebSocket连接，状态: ${global.wsRef.readyState}`)
@@ -1514,3 +1517,23 @@ window.addEventListener('beforeunload', () => {
 // ====== 模块加载计数 ======
 const global = getGlobalStorage()
 if (global.moduleLoadCount === 0) global.moduleLoadCount = 1
+
+// ponytail: 页面重载（如休眠恢复）后无 WS 时自动连接
+// 连接锁防并发，不会与正常初始化流程冲突
+// beginBootstrap 保证 App.vue 不黑屏
+setTimeout(async () => {
+  const g = getGlobalStorage()
+  if (!g.wsRef || g.wsRef.readyState !== WebSocket.OPEN) {
+    beginBootstrap()
+    logger.info('页面重载后检测到无 WebSocket，自动尝试连接')
+    setConnectionPermission(true, 'WebSocket自动重连')
+    await connectGlobalWebSocket('WebSocket自动重连')
+    for (let i = 0; i < 50; i++) {
+      if (g.wsRef?.readyState === WebSocket.OPEN) break
+      await new Promise(r => setTimeout(r, 200))
+    }
+    if (g.wsRef?.readyState === WebSocket.OPEN) {
+      markAsInitialized()
+    }
+  }
+}, 2000)


### PR DESCRIPTION
@
## 问题
MAS 进程运行时机器休眠，后端因 WS 断联触发 KillSelf 自杀，唤醒后前端无法重连，只能重启应用恢复。

## 根因
`app/api/core.py` WebSocket disconnect handler 在非 dev 模式下调用 `System.set_power("KillSelf")` 杀死后端进程。休眠导致的 WS 断联与正常关闭无法区分。

## 修改
- **core.py**: 移除 WS 断联时的 KillSelf，后端等待前端重连。正常关闭走 `/api/core/close` 显式退出
- **useWebSocket.ts**: `createGlobalWebSocket` 不再返回卡 CONNECTING 的僵死 WS，强制关闭重建
- **useWebSocket.ts**: 页面重载后无 WS 时自动连接 + beginBootstrap 防黑屏

## 设计
把后端生命周期决策权从 WS 连接状态解耦，收归 Electron 主进程管理。WS 回归纯数据通道角色。
@

## Summary by Sourcery

将后端进程的生命周期与 WebSocket 连接解耦，这样由于睡眠或网络导致的断连将不再终止后端进程，前端也可以自动恢复连接。

Bug Fixes:
- 防止在 WebSocket 因机器睡眠或网络问题断开时后端自我终止，从而允许在唤醒后重新连接。
- 确保处于 CONNECTING 状态且已失效的 WebSocket 会被关闭并重新创建，而不是被重复使用。
- 在没有活动连接的情况下，页面重新加载后自动重新建立全局 WebSocket 并完成应用初始化，避免出现空白屏幕状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Decouple backend process lifecycle from WebSocket connectivity so sleep- or network-induced disconnects no longer terminate the backend and the frontend can automatically recover the connection.

Bug Fixes:
- Prevent the backend from killing itself when the WebSocket disconnects due to machine sleep or network issues, allowing reconnection after wake.
- Ensure a stale WebSocket stuck in CONNECTING is closed and recreated instead of being reused.
- Automatically re-establish the global WebSocket and complete app initialization after page reloads when no active connection exists, avoiding a blank screen state.

</details>