### PR TITLE
fix(MaaEnd): 避免理智任务加载重置类型

### DIFF
--- a/app/models/config.py
+++ b/app/models/config.py
@@ -146,9 +146,6 @@ def _normalize_maaend_sanity_task_type(task_data: object) -> None:
         protocol_space_tab = task_data.get("ProtocolSpaceTab")
         if protocol_space_tab in MAAEND_SANITY_TASK_TYPES[:-1]:
             task_data["SanityTaskType"] = protocol_space_tab
-            return
-
-    task_data["SanityTaskType"] = MAAEND_SANITY_TASK_DEFAULTS["SanityTaskType"]
 
 
 class EmulatorConfig(ConfigBase):

--- a/tests/models/test_maaend_user_config.py
+++ b/tests/models/test_maaend_user_config.py
@@ -1,0 +1,32 @@
+import unittest
+
+from app.models.config import MaaEndUserConfig
+
+
+class MaaEndUserConfigTest(unittest.IsolatedAsyncioTestCase):
+    async def test_load_migrates_legacy_protocol_space_tab(self) -> None:
+        config = MaaEndUserConfig()
+
+        await config.load(
+            {
+                "Task": {
+                    "SanityTaskType": "ProtocolSpace",
+                    "ProtocolSpaceTab": "WeaponProgression",
+                }
+            }
+        )
+
+        self.assertEqual(config.get("Task", "SanityTaskType"), "WeaponProgression")
+
+    async def test_partial_task_load_keeps_existing_sanity_task_type(self) -> None:
+        config = MaaEndUserConfig()
+        await config.set("Task", "SanityTaskType", "CrisisDrills")
+
+        await config.load({"Task": {"RewardsSetOption": "RewardsSetB"}})
+
+        self.assertEqual(config.get("Task", "SanityTaskType"), "CrisisDrills")
+        self.assertEqual(config.get("Task", "RewardsSetOption"), "RewardsSetB")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- 收窄 MaaEnd 理智任务旧配置迁移逻辑：只迁移旧 ProtocolSpace + ProtocolSpaceTab。
- 不再在迁移函数里把缺失/未知 SanityTaskType 写成默认值，交给 ConfigItem/OptionsValidator 处理。
- 增加模型测试覆盖旧字段迁移和部分 Task 加载不重置类型。
- Tests: `python -m unittest tests.models.test_maaend_user_config -v`; `python -m compileall app\\models\\config.py tests\\models\\test_maaend_user_config.py`。