### PR TITLE
fix(okww): collapse game management settings

### DIFF
--- a/app/core/script_types.py
+++ b/app/core/script_types.py
@@ -270,7 +270,6 @@ class ScriptTypeRegistry:
             MaaFWUserConfig,
             MaaUserConfig,
             OkwwConfig,
-            OkwwUserConfig,
             SrcConfig,
             SrcUserConfig,
         )
@@ -343,17 +342,6 @@ class ScriptTypeRegistry:
                 manager_factory=_lazy_manager("app.task.MaaFW.manager", "MaaFWManager"),
                 icon="MaaFW",
                 editor_kind="builtin:maafw",
-                is_builtin=True,
-            ),
-            ScriptTypeProvider(
-                type_key="Okww",
-                display_name="ok-ww脚本",
-                script_config_class=OkwwConfig,
-                user_config_class=OkwwUserConfig,
-                supported_modes=("AutoProxy", "ScriptConfig"),
-                manager_factory=_lazy_manager("app.task.Okww.manager", "OkwwManager"),
-                icon="Okww",
-                editor_kind="builtin:okww",
                 is_builtin=True,
             ),
             ScriptTypeProvider(

--- a/app/plugins/manager.py
+++ b/app/plugins/manager.py
@@ -672,6 +672,7 @@ class _PluginManager:
 
         from app.core import Config
         from app.core.script_types import script_type_registry
+        from app.models.plugin_script_config import PluginScriptConfig
 
         owned_providers = [
             provider
@@ -684,6 +685,15 @@ class _PluginManager:
         bound_refs: list[str] = []
         for script_id, script in Config.ScriptConfig.items():
             for provider in owned_providers:
+                if isinstance(script, PluginScriptConfig):
+                    type_key = str(script.get("Meta", "PluginTypeKey") or "").strip()
+                    if type_key != provider.type_key:
+                        continue
+                    script_name = str(script.get("Info", "Name") or provider.display_name)
+                    bound_refs.append(
+                        f"{provider.type_key}:{script_name}({script_id})"
+                    )
+                    break
                 if not isinstance(script, provider.script_config_class):
                     continue
                 script_name = provider.display_name
@@ -716,6 +726,7 @@ class _PluginManager:
         from app.core import Config
         from app.models.ConfigBase import ConfigBase
         from app.models import config as config_models
+        from app.models.plugin_script_config import PluginScriptConfig
 
         _ = instance_id
         snapshot = discovered or self.loader.discovered_plugins or self._discover_plugins()
@@ -735,18 +746,33 @@ class _PluginManager:
             )
             return []
 
+        raw_adapter_type_keys = (
+            getattr(module, "SCRIPT_ADAPTER_TYPE_KEYS", None)
+            if module is not None
+            else None
+        ) or getattr(plugin_class, "SCRIPT_ADAPTER_TYPE_KEYS", ())
+        if not isinstance(raw_adapter_type_keys, tuple):
+            raw_adapter_type_keys = ()
+        adapter_type_keys = {
+            str(item).strip()
+            for item in raw_adapter_type_keys
+            if str(item or "").strip()
+        }
+
         raw_bindings = None
         if module is not None:
             raw_bindings = getattr(module, "SCRIPT_TYPE_BINDINGS", None)
         if raw_bindings is None:
             raw_bindings = getattr(plugin_class, "SCRIPT_TYPE_BINDINGS", None)
-        if raw_bindings is None:
+        if raw_bindings is None and not adapter_type_keys:
             return []
         if isinstance(raw_bindings, dict):
             raw_bindings = [raw_bindings]
+        if raw_bindings is None:
+            raw_bindings = []
         if not isinstance(raw_bindings, list):
             logger.warning(f"插件脚本类型绑定声明无效，已跳过: plugin={plugin_name}")
-            return []
+            raw_bindings = []
 
         bindings: list[tuple[str, str, type]] = []
         for item in raw_bindings:
@@ -762,6 +788,12 @@ class _PluginManager:
 
         bound_refs: list[str] = []
         for script_id, script in Config.ScriptConfig.items():
+            if isinstance(script, PluginScriptConfig):
+                type_key = str(script.get("Meta", "PluginTypeKey") or "").strip()
+                if type_key in adapter_type_keys:
+                    script_name = str(script.get("Info", "Name") or type_key)
+                    bound_refs.append(f"{type_key}:{script_name}({script_id})")
+                continue
             for type_key, display_name, config_class in bindings:
                 if not isinstance(script, config_class):
                     continue

--- a/frontend/src/composables/useOkwwConfigApi.ts
+++ b/frontend/src/composables/useOkwwConfigApi.ts
@@ -1,0 +1,86 @@
+import axios from 'axios'
+import { OpenAPI } from '@/api/core/OpenAPI'
+
+export interface OkwwConfigField {
+  name: string
+  type: string
+  label: string
+  description: string
+  value: unknown
+  options: string[] | null
+  min: number | null
+  max: number | null
+  step: number | null
+}
+
+export interface OkwwConfigFile {
+  filename: string
+  displayName: string
+  group: string
+  taskIndex: number | null
+  fieldCount: number
+  fields: OkwwConfigField[]
+  currentData: Record<string, unknown>
+}
+
+export interface OkwwConfigListResponse {
+  code?: number
+  status?: string
+  message?: string
+  data?: OkwwConfigFile[]
+  optionLabels?: Record<string, string>
+  configPath?: string
+}
+
+export interface OkwwConfigUpdateResponse {
+  code?: number
+  status?: string
+  message?: string
+  data?: string[]
+}
+
+export type OkwwConfigPatchMap = Record<string, Record<string, unknown>>
+
+export const useOkwwConfigApi = (endpointPrefix: string) => {
+  const requestUrl = (path: string) => `${OpenAPI.BASE}${endpointPrefix}${path}`
+  const isPluginEndpoint = () => endpointPrefix.startsWith('/plugin/')
+
+  const listConfigFiles = async (
+    scriptId: string,
+    userId: string
+  ): Promise<OkwwConfigListResponse> => {
+    if (isPluginEndpoint()) {
+      const response = await axios.post(requestUrl('/list'), {
+        script_id: scriptId,
+        user_id: userId,
+      })
+      return response.data
+    }
+
+    const response = await axios.post(requestUrl('/list'), null, {
+      params: {
+        script_id: scriptId,
+        user_id: userId,
+      },
+    })
+    return response.data
+  }
+
+  const batchUpdateConfigFiles = async (
+    scriptId: string,
+    userId: string,
+    configsToUpdate: OkwwConfigPatchMap
+  ): Promise<OkwwConfigUpdateResponse> => {
+    const response = await axios.post(requestUrl('/batch-update'), {
+      script_id: scriptId,
+      user_id: userId,
+      configs: configsToUpdate,
+    })
+    return response.data
+  }
+
+  return {
+    listConfigFiles,
+    batchUpdateConfigFiles,
+  }
+}

--- a/frontend/src/views/EditView/User/PluginUserEdit.vue
+++ b/frontend/src/views/EditView/User/PluginUserEdit.vue
@@ -50,10 +50,18 @@
       :hide-fields="headerSchemaActionKeys"
       :action-loading-id="actionLoadingId"
       @trigger-action="({ field, fieldSchema }) => handleFieldAction(field, fieldSchema)"
-      @validation-change="(errors) => (fieldErrors = errors)"
+      @validation-change="errors => (fieldErrors = errors)"
     />
 
     <a-empty v-if="!userSchema && !loading" description="此插件脚本类型未提供用户配置表单" />
+  </a-card>
+
+  <a-card v-if="isOkwwAdapter && userId" class="config-card okww-config-card">
+    <OkwwConfigEditor
+      :script-id="scriptId"
+      :user-id="userId"
+      endpoint-prefix="/plugin/okww/configs"
+    />
   </a-card>
 
   <SchemaActionSessionMask
@@ -73,6 +81,7 @@ import { message } from 'ant-design-vue'
 import HeaderSchemaActionButton from '@/components/HeaderSchemaActionButton.vue'
 import SchemaForm from '@/components/SchemaForm.vue'
 import SchemaActionSessionMask from '@/components/SchemaActionSessionMask.vue'
+import OkwwConfigEditor from '@/views/OkwwUserEdit/OkwwConfigEditor.vue'
 import { useSchemaActionRunner } from '@/composables/useSchemaActionRunner'
 import { useWebSocket, type WebSocketBaseMessage } from '@/composables/useWebSocket'
 import { useScriptRegistryApi } from '@/composables/useScriptRegistryApi'
@@ -81,7 +90,11 @@ import type {
   SchemaFieldDefinition,
   SchemaValidationErrorMap,
 } from '@/types/schemaForm'
-import { descriptorMapFromList, getScriptTypeTagColor, normalizeScriptRecord } from '@/utils/scriptRegistry'
+import {
+  descriptorMapFromList,
+  getScriptTypeTagColor,
+  normalizeScriptRecord,
+} from '@/utils/scriptRegistry'
 import { collectHeaderSchemaActions } from '@/utils/schemaActions'
 
 const logger = window.electronAPI.getLogger('插件用户编辑')
@@ -145,7 +158,7 @@ const displayNameFromForm = computed(() => {
   return ''
 })
 
-const cloneValue = <T>(value: T): T => JSON.parse(JSON.stringify(value))
+const cloneValue = <T,>(value: T): T => JSON.parse(JSON.stringify(value))
 
 const normalizePluginKey = (value?: string | null) =>
   String(value || '')
@@ -159,6 +172,8 @@ const currentPluginKey = () => {
   }
   return normalizePluginKey(editorKind.slice('plugin:'.length))
 }
+
+const isOkwwAdapter = computed(() => currentPluginKey() === 'okwwadapter')
 
 const isCurrentPluginEvent = (plugin?: string | null) => {
   const key = currentPluginKey()
@@ -183,7 +198,10 @@ const loadData = async ({
   loading.value = true
   const preservedFormModel = preserveFormModel ? cloneValue(formModel.value || {}) : null
   try {
-    const [descriptors, scripts] = await Promise.all([api.getScriptTypes(), api.getScripts(scriptId)])
+    const [descriptors, scripts] = await Promise.all([
+      api.getScriptTypes(),
+      api.getScripts(scriptId),
+    ])
     const scriptRecord = scripts[0]
     if (!scriptRecord) {
       throw new Error('脚本不存在')
@@ -285,10 +303,7 @@ const refreshImportedInfrastructure = async () => {
 }
 
 const handlePluginSystemMessage = (wsMessage: WebSocketBaseMessage) => {
-  const payload = wsMessage.data as
-    | PluginSystemSnapshotMessage
-    | PluginSystemHmrMessage
-    | undefined
+  const payload = wsMessage.data as PluginSystemSnapshotMessage | PluginSystemHmrMessage | undefined
   if (!payload || typeof payload !== 'object') {
     return
   }
@@ -299,9 +314,9 @@ const handlePluginSystemMessage = (wsMessage: WebSocketBaseMessage) => {
   }
 
   if (
-    payload.kind === 'hmr'
-    && payload.status === 'error'
-    && isCurrentPluginEvent(payload.plugin)
+    payload.kind === 'hmr' &&
+    payload.status === 'error' &&
+    isCurrentPluginEvent(payload.plugin)
   ) {
     message.warning(payload.message || `plugin hmr failed: ${payload.plugin || 'unknown'}`)
   }
@@ -321,7 +336,10 @@ const {
     await loadData()
   },
   onActionSuccess: async ({ field, action }) => {
-    if (field !== 'Data.ImportCustomInfrast' || action.path !== '/api/scripts/user/infrastructure') {
+    if (
+      field !== 'Data.ImportCustomInfrast' ||
+      action.path !== '/api/scripts/user/infrastructure'
+    ) {
       return false
     }
     await refreshImportedInfrastructure()
@@ -392,6 +410,10 @@ onUnmounted(() => {
 
 .config-card {
   border-radius: 16px;
+}
+
+.okww-config-card {
+  margin-top: 16px;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/views/OkwwUserEdit/OkwwConfigEditor.vue
+++ b/frontend/src/views/OkwwUserEdit/OkwwConfigEditor.vue
@@ -191,34 +191,22 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import { message } from 'ant-design-vue'
-import { OkwwService } from '@/api/services/OkwwService'
+import {
+  useOkwwConfigApi,
+  type OkwwConfigFile as ConfigFile,
+  type OkwwConfigPatchMap,
+} from '@/composables/useOkwwConfigApi'
 
-interface ConfigField {
-  name: string
-  type: string
-  label: string
-  description: string
-  value: any
-  options: string[] | null
-  min: number | null
-  max: number | null
-  step: number | null
-}
-
-interface ConfigFile {
-  filename: string
-  displayName: string
-  group: string
-  taskIndex: number | null
-  fieldCount: number
-  fields: ConfigField[]
-  currentData: Record<string, any>
-}
-
-const props = defineProps<{
-  scriptId: string
-  userId: string
-}>()
+const props = withDefaults(
+  defineProps<{
+    scriptId: string
+    userId: string
+    endpointPrefix?: string
+  }>(),
+  {
+    endpointPrefix: '/api/scripts/okww/configs',
+  }
+)
 
 const emit = defineEmits<{
   saved: []
@@ -260,6 +248,7 @@ const selectedConfig = computed(() => {
 
 const selectedConfigForTemplate = computed<ConfigFile>(() => selectedConfig.value || emptyConfig)
 const hasChanges = computed(() => changedFiles.value.size > 0)
+const okwwConfigApi = useOkwwConfigApi(props.endpointPrefix)
 
 const getOptionLabel = (value: string) => {
   return optionLabels.value[value] || value
@@ -304,10 +293,7 @@ const loadConfigs = async () => {
   if (!props.scriptId || !props.userId) return
   loading.value = true
   try {
-    const resp = await OkwwService.getOkwwConfigsListApiScriptsOkwwConfigsListPost(
-      props.scriptId,
-      props.userId
-    )
+    const resp = await okwwConfigApi.listConfigFiles(props.scriptId, props.userId)
     if (resp?.code === 200 && resp?.data) {
       configs.value = resp.data
       optionLabels.value = resp.optionLabels || {}
@@ -334,12 +320,12 @@ const loadConfigs = async () => {
 const saveAll = async (silent = true) => {
   if (!hasChanges.value) return
   try {
-    const configsToUpdate = { ...localChanges.value }
-    const resp = await OkwwService.batchUpdateOkwwConfigsApiScriptsOkwwConfigsBatchUpdatePost({
-      script_id: props.scriptId,
-      user_id: props.userId,
-      configs: configsToUpdate,
-    })
+    const configsToUpdate: OkwwConfigPatchMap = { ...localChanges.value }
+    const resp = await okwwConfigApi.batchUpdateConfigFiles(
+      props.scriptId,
+      props.userId,
+      configsToUpdate
+    )
     if (resp?.code === 200) {
       // 更新本地数据
       for (const [filename, data] of Object.entries(configsToUpdate)) {

--- a/plugins/okww_adapter/README.md
+++ b/plugins/okww_adapter/README.md
@@ -1,0 +1,21 @@
+# OK-WW Adapter
+
+AUTO-MAS pluginized OK-WW script adapter.
+
+## Scope
+
+- Registers the `Okww` script type from a plugin instead of the host builtin registry.
+- Keeps the ok-script behavior from `dev`: `ok-ww.exe -t {TaskIndex} -e`.
+- Provides schema-driven script/user forms for `PluginScriptEdit` and `PluginUserEdit`.
+- Moves OK-WW config-file service endpoints to plugin routes:
+  - `/plugin/okww/configs/list`
+  - `/plugin/okww/configs/update`
+  - `/plugin/okww/configs/batch-update`
+
+## Compatibility Notes
+
+The host still keeps legacy `OkwwConfig` / `OkwwUserConfig` classes so existing config
+files can load. New plugin records are stored through `PluginScriptConfig`.
+
+The old embedded Vue `OkwwConfigEditor` is not wired into the plugin UI yet; the backend
+routes are present so a plugin page or schema action can be added next.

--- a/plugins/okww_adapter/pyproject.toml
+++ b/plugins/okww_adapter/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "automas_plugin_okww_adapter"
+version = "0.0.1"
+description = "OK-WW script adapter for AUTO-MAS"
+readme = { file = "README.md", content-type = "text/markdown" }
+requires-python = ">=3.10"
+dependencies = []
+
+[project.entry-points."auto_mas.plugins"]
+okww_adapter = "okww_adapter.plugin:Plugin"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/plugins/okww_adapter/src/okww_adapter/__init__.py
+++ b/plugins/okww_adapter/src/okww_adapter/__init__.py
@@ -1,0 +1,6 @@
+"""OK-WW script adapter plugin."""
+
+from .plugin import Plugin
+from .schema import Config, OkwwConfig, OkwwUserConfig, PluginConfig
+
+__all__ = ["Plugin", "Config", "PluginConfig", "OkwwConfig", "OkwwUserConfig"]

--- a/plugins/okww_adapter/src/okww_adapter/adapter/__init__.py
+++ b/plugins/okww_adapter/src/okww_adapter/adapter/__init__.py
@@ -1,0 +1,5 @@
+"""OK-WW adapter runtime exports."""
+
+from .runtime import OkwwAdapterHooks
+
+__all__ = ["OkwwAdapterHooks"]

--- a/plugins/okww_adapter/src/okww_adapter/adapter/autoproxy.py
+++ b/plugins/okww_adapter/src/okww_adapter/adapter/autoproxy.py
@@ -1,0 +1,561 @@
+#   AUTO-MAS: A Multi-Script, Multi-Config Management and Automation Software
+#   Copyright © 2025-2026 AUTO-MAS Team
+#
+#   This file is part of AUTO-MAS.
+#
+#   AUTO-MAS is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of
+#   the License, or (at your option) any later version.
+#
+#   AUTO-MAS is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+#   the GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with AUTO-MAS. If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import asyncio
+import shlex
+import shutil
+import uuid
+from contextlib import suppress
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from app.core import Config
+from app.models.task import TaskExecuteBase, ScriptItem, UserItem, LogRecord
+from app.models.ConfigBase import ConfigBase, MultipleConfig
+from app.services import Notify, System
+from app.utils import get_logger, ProcessManager, ProcessInfo, is_process_running
+from app.utils.LogMonitor import LogMonitor
+from app.utils.constants import UTC4
+from app.task.general.tools import execute_script_task
+
+logger = get_logger("OK-WW 自动代理")
+
+# 鸣潮 PC 客户端窗口进程名固定，MAS 接管启动前据此避免重复拉起
+_WUWA_CLIENT_PROCESS = "Client-Win64-Shipping.exe"
+
+
+def _yes_no(value: bool) -> str:
+    return "是" if value else "否"
+
+# ── okww 专项硬编码（不存 ConfigItem，随 MAS 版本同步）──────────────
+# 对齐 MaaEnd：专项内置日志片段，Okww 不向用户暴露成功/失败日志关键词配置。
+_OKWW_BUILTIN_FATAL: tuple[tuple[str, str], ...] = (
+    ("connected:False", "OK-WW 未连接游戏客户端"),
+    ("游戏更新成功, 游戏即将重启", "游戏更新成功，即将重启任务"),
+    ("info_set 错误", "OK-WW 流程产生错误，请检查游戏状态"),
+)
+
+# ok-ww 项目结构固定相对路径（从 RootPath 派生，不依赖用户存储值）
+# ⚠️ 与前端 OkwwScriptEdit.vue 的 OKWW_EXE_NAME 保持同步，改这里时需同步改前端
+_OKWW_REL_EXE = "ok-ww.exe"
+_OKWW_REL_CONFIG_DIR = "data/apps/ok-ww/working/configs"
+_OKWW_REL_LOG_FILE = "data/apps/ok-ww/working/logs/ok-script.log"
+_OKWW_REL_PYTHONW = "data/apps/ok-ww/python/pythonw.exe"
+_OKWW_TRACK_PROCESS_NAME = "pythonw.exe"
+_OKWW_LOG_TIME_START = 1
+_OKWW_LOG_TIME_END = 23
+_OKWW_LOG_TIME_FORMAT = "%Y-%m-%d %H:%M:%S,%f"
+
+
+def _split_args(raw: object) -> list[str]:
+    value = str(raw or "").strip()
+    return shlex.split(value, posix=False) if value else []
+
+
+
+class AutoProxyTask(TaskExecuteBase):
+    """OK-WW 自动代理：拼 `-t N -e` 启动参数并监控日志"""
+
+    def __init__(
+        self,
+        script_info: ScriptItem,
+        script_config: ConfigBase,
+        user_config: MultipleConfig[ConfigBase],
+        game_manager: ProcessManager | None,
+    ):
+        super().__init__()
+        if script_info.task_info is None:
+            raise RuntimeError("ScriptItem 未绑定到 TaskItem")
+
+        self.task_info = script_info.task_info
+        self.script_info = script_info
+        self.script_config = script_config
+        self.user_config = user_config
+        self.game_manager = game_manager
+
+        self.cur_user_item: UserItem = self.script_info.user_list[self.script_info.current_index]
+        self.cur_user_uid = uuid.UUID(self.cur_user_item.user_id)
+        self.cur_user_config: ConfigBase = self.user_config[self.cur_user_uid]
+        self.manual_stop_requested = False
+
+    async def check(self) -> str:
+        root = Path(self.script_config.get("Info", "RootPath"))
+        if not root.is_dir():
+            return "请设置ok-ww脚本路径"
+        if not (root / _OKWW_REL_EXE).is_file():
+            return "请设置ok-ww脚本路径"
+        if (
+            self.script_config.get("Run", "ProxyTimesLimit") != 0
+            and self.cur_user_config.get("Data", "ProxyTimes")
+            >= self.script_config.get("Run", "ProxyTimesLimit")
+        ):
+            self.cur_user_item.status = "跳过"
+            return "今日代理次数已达上限, 跳过该用户"
+        if self.cur_user_config.get("Info", "RemainedDay") == 0:
+            self.cur_user_item.status = "跳过"
+            return "用户剩余天数为 0, 跳过该用户"
+
+        if (
+            self._game_management_enabled()
+            and not Path(self.script_config.get("Game", "Path")).is_file()
+        ):
+            return "请设置鸣潮游戏路径"
+
+        mas_config_dir = self._okww_mas_config_dir()
+        if not (mas_config_dir.is_dir() and any(
+            item.is_file() for item in mas_config_dir.rglob("*")
+        )):
+            return (
+                f"用户 {self.cur_user_item.name} 未完成 OK-WW 配置，"
+                "请先在用户编辑页保存配置"
+            )
+        return "Pass"
+
+    async def prepare(self):
+        self.okww_process_manager = ProcessManager()
+        self.wait_event = asyncio.Event()
+
+        self.user_start_time = datetime.now()
+        self.log_start_time = datetime.now()
+
+        # ── 所有 Script 路径从 RootPath 实时派生，不依赖 ConfigItem 存储值 ──
+        self.script_root_path = Path(self.script_config.get("Info", "RootPath"))
+        self.script_exe_path = self.script_root_path / _OKWW_REL_EXE
+
+        self.script_target_process_info = ProcessInfo(
+            name=_OKWW_TRACK_PROCESS_NAME,
+            exe=str(self.script_root_path / _OKWW_REL_PYTHONW),
+            cmdline=None,
+        )
+
+        self.script_log_path = self.script_root_path / _OKWW_REL_LOG_FILE
+
+        self.log_time_range = (_OKWW_LOG_TIME_START - 1, _OKWW_LOG_TIME_END)
+        self.log_time_format = _OKWW_LOG_TIME_FORMAT
+        self.log_monitor = LogMonitor(
+            self.log_time_range,
+            self.log_time_format,
+            self.check_log,
+        )
+
+        self.task_index = int(self.cur_user_config.get("Task", "TaskIndex"))
+        self.okww_args = ["-t", str(self.task_index), "-e"]
+
+        # 游戏配置（对齐通用脚本逻辑）
+        self.game_path = Path(self.script_config.get("Game", "Path"))
+        self.script_config_path = self.script_root_path / _OKWW_REL_CONFIG_DIR
+
+        self.run_book = False
+
+    def _okww_mas_config_dir(self) -> Path:
+        return (
+            Path.cwd()
+            / "data"
+            / self.script_info.script_id
+            / str(self.cur_user_uid)
+            / "ConfigFile"
+        )
+
+    async def set_okww(self) -> None:
+        """将 MAS 侧 OK-WW 任务配置下发到脚本 working 目录（对齐 General.set_general）。"""
+
+        logger.info("开始配置 OK-WW 运行参数: 自动代理")
+        await System.kill_process(self.script_exe_path)
+
+        mas_config_dir = self._okww_mas_config_dir()
+        tmp_dst = self.script_config_path.with_name(
+            self.script_config_path.name + ".tmp"
+        )
+        shutil.rmtree(tmp_dst, ignore_errors=True)
+        shutil.copytree(mas_config_dir, tmp_dst, dirs_exist_ok=True)
+        shutil.rmtree(self.script_config_path, ignore_errors=True)
+        tmp_dst.rename(self.script_config_path)
+        logger.info(f"OK-WW 运行参数配置完成: 自动代理")
+
+    async def update_config(self) -> None:
+        """将脚本侧配置回写 MAS ConfigFile（对齐 General.update_config）。"""
+
+        mas_config_dir = self._okww_mas_config_dir()
+        tmp_dst = mas_config_dir.with_name(mas_config_dir.name + ".tmp")
+        shutil.rmtree(tmp_dst, ignore_errors=True)
+        shutil.copytree(self.script_config_path, tmp_dst, dirs_exist_ok=True)
+        shutil.rmtree(mas_config_dir, ignore_errors=True)
+        tmp_dst.rename(mas_config_dir)
+        logger.success("OK-WW 配置文件已更新")
+
+    def _game_config_summary_lines(self) -> list[str]:
+        """游戏配置摘要行（调度台展示用）。"""
+
+        game_args = str(self.script_config.get("Game", "Arguments") or "").strip()
+        game_enabled = bool(self.script_config.get("Game", "Enabled"))
+        close_on_manual_stop = bool(self.script_config.get("Game", "CloseOnManualStop"))
+        return [
+            f"[游戏配置] 用户: {self.cur_user_item.name}",
+            f"  启用游戏配置: {_yes_no(game_enabled)}",
+            f"  由 MAS 启动并关闭游戏: {_yes_no(game_enabled)}",
+            f"  手动终止时关闭游戏: {_yes_no(game_enabled and close_on_manual_stop)}",
+            f"  启动参数: {game_args or '（无）'}",
+        ]
+
+    async def _push_dispatch_log(self, line: str) -> None:
+        """向调度台追加流程日志（赋值 script_info.log 会触发 WebSocket 推送）。"""
+
+        prev = self.script_info.log
+        self.script_info.log = f"{prev}\n{line}" if prev else line
+        await asyncio.sleep(0)
+
+    async def _log_game_config_summary(self) -> None:
+        """在调度台开头输出当前脚本的游戏相关配置，便于用户确认与问题排查。"""
+
+        self.script_info.log = "\n".join(self._game_config_summary_lines())
+        await asyncio.sleep(0)
+
+    async def _mas_launch_game_before_task(self) -> None:
+        """MAS 接管启动游戏，并将各步骤写入调度台日志。"""
+
+        await self._push_dispatch_log("正在准备由 MAS 启动游戏...")
+
+        if isinstance(self.game_manager, ProcessManager):
+            await self._push_dispatch_log(
+                f"正在检查鸣潮客户端进程 ({_WUWA_CLIENT_PROCESS})..."
+            )
+            if is_process_running(_WUWA_CLIENT_PROCESS):
+                logger.info(
+                    "检测到鸣潮客户端进程已在运行，跳过由 MAS 重复启动游戏"
+                )
+                await self._push_dispatch_log("检测到客户端已在运行，跳过启动")
+                return
+
+            await self._push_dispatch_log("未检测到运行中的客户端，正在拉起游戏...")
+            await self.game_manager.open_process(
+                self.game_path,
+                *_split_args(self.script_config.get("Game", "Arguments")),
+            )
+            wait_time = int(self.script_config.get("Game", "WaitTime"))
+            await self._push_dispatch_log(
+                f"正在等待游戏完成启动（{wait_time}s）..."
+            )
+            await asyncio.sleep(wait_time)
+            await self._push_dispatch_log("游戏启动完成")
+            return
+
+    async def main_task(self):
+        await self.prepare()
+        self.curdate = datetime.now(tz=UTC4).strftime("%Y-%m-%d")
+        if self.cur_user_config.get("Data", "LastProxyDate") != self.curdate:
+            await self.cur_user_config.set("Data", "LastProxyDate", self.curdate)
+            await self.cur_user_config.set("Data", "ProxyTimes", 0)
+
+        self.cur_user_item.status = "运行"
+
+        run_limit = int(self.script_config.get("Run", "RunTimesLimit"))
+        for i in range(run_limit):
+            if self.run_book:
+                break
+            logger.info(
+                f"用户 {self.cur_user_item.name} - 尝试次数: {i + 1}/{run_limit}"
+            )
+            self.cur_user_item.status = "运行"
+            self.log_start_time = datetime.now()
+            self.cur_user_item.log_record[self.log_start_time] = LogRecord()
+            self.cur_user_log = self.cur_user_item.log_record[self.log_start_time]
+
+            if self.cur_user_config.get("Info", "IfScriptBeforeTask"):
+                await execute_script_task(
+                    Path(self.cur_user_config.get("Info", "ScriptBeforeTask")),
+                    "脚本前任务",
+                )
+
+            await self._log_game_config_summary()
+
+            # 启用游戏配置时始终由 MAS 拉起游戏
+            if self._game_management_enabled() and self.game_manager is not None:
+                try:
+                    await self._mas_launch_game_before_task()
+                except Exception as e:
+                    await self._push_dispatch_log(f"游戏启动失败: {e}")
+                    self.cur_user_log.status = f"游戏启动失败: {e}"
+                    self.cur_user_log.content = [f"游戏启动失败: {e}"]
+                    await Config.send_websocket_message(
+                        id=self.task_info.task_id,
+                        type="Info",
+                        data={"Error": f"游戏启动失败: {e}"},
+                    )
+                    await self.kill_managed_process(
+                        kill_game=self._game_management_enabled()
+                    )
+                    try:
+                        await Notify.push_plyer(
+                            "OK-WW 自动代理出现异常！",
+                            f"用户 {self.cur_user_item.name} 游戏启动失败",
+                            f"{self.cur_user_item.name}的自动代理出现异常",
+                            3,
+                        )
+                    except Exception:
+                        pass
+                    if i + 1 < run_limit:
+                        await self._push_dispatch_log(
+                            f"游戏启动失败，将在稍后重试 ({i + 1}/{run_limit})"
+                        )
+                        await asyncio.sleep(10)
+                    else:
+                        self.cur_user_item.status = "异常"
+                    continue
+
+            await self.set_okww()
+            await self._push_dispatch_log(
+                f"启动 OK-WW: -t {self.task_index} -e"
+            )
+            logger.info(
+                f"启动 OK-WW 进程: {self.script_exe_path} {' '.join(self.okww_args)}"
+            )
+
+            await self.okww_process_manager.open_process(
+                self.script_exe_path,
+                *self.okww_args,
+                target_process=self.script_target_process_info,
+            )
+
+            # 启动日志监控（文件日志）
+            await asyncio.sleep(1)
+            await self.log_monitor.start_monitor_file(
+                self.script_log_path, self.log_start_time
+            )
+
+            self.wait_event.clear()
+            await self.wait_event.wait()
+            await self.log_monitor.stop()
+
+            if self.cur_user_log.status == "Success!":
+                self.run_book = True
+                self.script_info.log = (
+                    "检测到 OK-WW 已完成任务\n正在等待 OK-WW 自行退出"
+                )
+                # 等待 OK-WW 自然退出（-e 标志使其任务完成后自行关闭游戏并退出）
+                await self._wait_okww_exit(timeout=30)
+                await self.update_config()
+                if self.cur_user_config.get("Info", "IfScriptAfterTask"):
+                    await execute_script_task(
+                        Path(self.cur_user_config.get("Info", "ScriptAfterTask")),
+                        "脚本后任务",
+                    )
+                await asyncio.sleep(3)
+                break
+
+            logger.error(
+                f"用户 {self.cur_user_item.name} - OK-WW 代理异常: {self.cur_user_log.status}"
+            )
+            self.script_info.log = (
+                f"{self.cur_user_log.status}\n正在中止相关程序"
+            )
+            await self.kill_managed_process(
+                kill_game=self._game_management_enabled()
+            )
+            try:
+                await Notify.push_plyer(
+                    "OK-WW 自动代理出现异常！",
+                    f"用户 {self.cur_user_item.name} 的自动代理出现一次异常",
+                    f"{self.cur_user_item.name}的自动代理出现异常",
+                    3,
+                )
+            except Exception:
+                pass
+            await self.update_config()
+            if self.cur_user_config.get("Info", "IfScriptAfterTask"):
+                await execute_script_task(
+                    Path(self.cur_user_config.get("Info", "ScriptAfterTask")),
+                    "脚本后任务",
+                )
+            if i + 1 < run_limit:
+                self.script_info.log += (
+                    f"\n将在稍后重试 ({i + 1}/{run_limit})"
+                )
+                await asyncio.sleep(10)
+
+    def _game_management_enabled(self) -> bool:
+        return bool(self.script_config.get("Game", "Enabled"))
+
+    def _should_close_game_after_finish(self) -> bool:
+        if not self._game_management_enabled():
+            return False
+        if self.manual_stop_requested:
+            return bool(self.script_config.get("Game", "CloseOnManualStop"))
+        return True
+
+    async def check_log(self, log_content: list[str], latest_time: datetime) -> None:
+        """失败靠内置日志关键词；成功靠进程窗口关闭（-e 自然退出）。"""
+        log = "".join(log_content)
+        self.cur_user_log.content = log_content
+        self.script_info.log = log[-4000:] if len(log) > 4000 else log
+
+        log_status = "OK-WW 正常运行中"
+        user_item_status: str | None = None
+
+        for needle, msg in _OKWW_BUILTIN_FATAL:
+            if needle in log:
+                log_status = msg
+                user_item_status = "异常"
+                break
+        else:
+            if not await self.okww_process_manager.is_running():
+                log_status = "Success!"
+                user_item_status = "完成"
+            elif datetime.now() - latest_time > timedelta(
+                minutes=self.script_config.get("Run", "RunTimeLimit")
+            ):
+                log_status = "OK-WW 运行超时"
+                user_item_status = "异常"
+
+        self.cur_user_log.status = log_status
+        if user_item_status is not None:
+            self.cur_user_item.status = user_item_status
+
+        logger.debug(f"OK-WW 日志分析结果: {self.cur_user_log.status}")
+        if self.cur_user_log.status != "OK-WW 正常运行中":
+            logger.info(f"OK-WW 任务结果: {self.cur_user_log.status}, 日志锁已释放")
+            self.wait_event.set()
+
+    async def final_task(self):
+        # 结束时先清理进程与监控；任务结束后始终关闭游戏（由 Game.Enabled 总开关控制）
+        with suppress(Exception):
+            await self.log_monitor.stop()
+        await self.kill_managed_process(kill_game=self._should_close_game_after_finish())
+
+        # 写入历史记录（对齐 General/SRC/MaaEnd 行为）
+        for t, log_item in self.cur_user_item.log_record.items():
+            dt = t.replace(tzinfo=datetime.now().astimezone().tzinfo).astimezone(UTC4)
+            log_path = (
+                Path.cwd()
+                / f"history/{dt.strftime('%Y-%m-%d')}/{self.cur_user_item.name}/{dt.strftime('%H-%M-%S')}.log"
+            )
+
+            if log_item.status == "OK-WW 正常运行中":
+                log_item.status = "任务被用户手动中止"
+
+            if len(log_item.content) == 0:
+                log_item.content = ["未捕获到任何日志内容"]
+                log_item.status = "未捕获到日志"
+
+            await Config.save_general_log(log_path, log_item.content, log_item.status)
+
+        await self._persist_user_run_result()
+
+    async def _persist_user_run_result(self) -> None:
+        if self.cur_user_config is None:
+            return
+
+        await self.cur_user_config.set("Data", "LastTaskIndex", getattr(self, "task_index", 0))
+        if self.run_book:
+            if (
+                self.cur_user_config.get("Data", "ProxyTimes") == 0
+                and self.cur_user_config.get("Info", "RemainedDay") != -1
+            ):
+                await self.cur_user_config.set(
+                    "Info",
+                    "RemainedDay",
+                    self.cur_user_config.get("Info", "RemainedDay") - 1,
+                )
+            await self.cur_user_config.set(
+                "Data",
+                "ProxyTimes",
+                self.cur_user_config.get("Data", "ProxyTimes") + 1,
+            )
+            await self.cur_user_config.set("Data", "LastProxyStatus", "成功")
+            self.cur_user_item.status = "完成"
+            logger.success(f"用户 {self.cur_user_uid} 的 OK-WW 自动代理任务已完成")
+        else:
+            await self.cur_user_config.set("Data", "LastProxyStatus", "失败")
+            if self.cur_user_item.status != "完成":
+                self.cur_user_item.status = "异常"
+
+    async def on_crash(self, e: Exception):
+        self.cur_user_item.status = "异常"
+        if hasattr(self, "cur_user_log"):
+            self.cur_user_log.status = f"OK-WW 运行异常: {e}"
+        logger.exception(f"OK-WW 自动代理任务出现异常: {e}")
+        if hasattr(self, "wait_event"):
+            self.wait_event.set()
+        await Config.send_websocket_message(
+            id=self.task_info.task_id,
+            type="Info",
+            data={"Error": f"OK-WW 自动代理任务出现异常: {e}"},
+        )
+        await self.kill_managed_process(
+            kill_game=self._game_management_enabled()
+        )
+        await self._persist_user_run_result()
+
+        # 推送通知（复用 Notify）
+        try:
+            if (
+                hasattr(self, "cur_user_log")
+                and self.cur_user_log.status
+                and self.cur_user_log.status != "Success!"
+            ):
+                await Notify.push_plyer(
+                    "OK-WW 运行异常",
+                    f"用户 {self.cur_user_item.name}：{self.cur_user_log.status}",
+                    "异常",
+                    3,
+                )
+        except Exception:
+            pass
+
+    async def _wait_okww_exit(self, *, timeout: int = 30) -> None:
+        """等待 OK-WW 自然退出（-e 触发），超时后兜底强杀。"""
+        deadline = datetime.now() + timedelta(seconds=timeout)
+        while datetime.now() < deadline:
+            if not await self.okww_process_manager.is_running():
+                logger.info("OK-WW 已自行退出")
+                return
+            await asyncio.sleep(1)
+        logger.warning(f"OK-WW 未在 {timeout}s 内自行退出，兜底强杀")
+        await self._kill_okww_process()
+
+    async def _kill_okww_process(self) -> None:
+        try:
+            await self.okww_process_manager.kill()
+        except Exception as e:
+            logger.exception(f"通过进程管理器中止 OK-WW 进程失败: {e}")
+        try:
+            await System.kill_process(self.script_exe_path)
+        except Exception as e:
+            logger.exception(f"中止 OK-WW 主进程失败: {e}")
+        track_exe = self.script_root_path / _OKWW_REL_PYTHONW
+        try:
+            await System.kill_process(track_exe)
+        except Exception as e:
+            logger.exception(f"中止 OK-WW 追踪进程失败: {e}")
+
+    async def _kill_game_process(self) -> None:
+        """结束游戏：任务结束/失败/异常时始终触发（由 Game.Enabled 总开关控制）"""
+        try:
+            if isinstance(self.game_manager, ProcessManager):
+                await self.game_manager.kill()
+            if self.game_path.is_file():
+                await System.kill_process(self.game_path)
+        except Exception as e:
+            logger.exception(f"关闭游戏进程失败: {e}")
+
+    async def kill_managed_process(self, *, kill_game: bool = True) -> None:
+        """中止 ok-ww；kill_game 为真时结束游戏"""
+        await self._kill_okww_process()
+        if kill_game:
+            await self._kill_game_process()

--- a/plugins/okww_adapter/src/okww_adapter/adapter/runtime.py
+++ b/plugins/okww_adapter/src/okww_adapter/adapter/runtime.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import asyncio
+import shutil
+import uuid
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+from app.core import Config
+from app.models.ConfigBase import ConfigBase, MultipleConfig
+from app.models.task import TaskExecuteBase, UserItem
+from app.plugins import ScriptAdapterHooks, ScriptAdapterRuntime
+from app.services import System
+from app.utils import ProcessManager, get_logger
+
+from .autoproxy import AutoProxyTask, _OKWW_REL_CONFIG_DIR
+
+logger = get_logger("OK-WW 插件适配")
+
+
+def _cfg_get(config: ConfigBase | None, group: str, name: str, default: Any = None) -> Any:
+    if config is None:
+        return default
+    try:
+        value = config.get(group, name)
+    except Exception:
+        return default
+    return default if value is None else value
+
+
+def _user_name(config: ConfigBase | None, fallback: str) -> str:
+    value = _cfg_get(config, "Info", "Name", fallback)
+    return str(value or fallback)
+
+
+def _user_enabled(config: ConfigBase | None) -> bool:
+    return bool(_cfg_get(config, "Info", "Status", True))
+
+
+class _CheckedAutoProxyTask(TaskExecuteBase):
+    def __init__(self, inner: AutoProxyTask) -> None:
+        super().__init__()
+        self.inner = inner
+
+    async def main_task(self) -> None:
+        try:
+            result = await self.inner.check()
+            if result != "Pass":
+                current_user = self.inner.cur_user_item
+                if current_user.status == "等待":
+                    current_user.status = "异常"
+                await Config.send_websocket_message(
+                    id=self.inner.task_info.task_id,
+                    type="Info",
+                    data={"Error": result},
+                )
+                return
+            await self.inner.main_task()
+        except asyncio.CancelledError:
+            self.inner.manual_stop_requested = True
+            raise
+
+    async def final_task(self) -> None:
+        await self.inner.final_task()
+
+    async def on_crash(self, error: Exception) -> None:
+        await self.inner.on_crash(error)
+
+
+class OkwwAdapterHooks(ScriptAdapterHooks):
+    async def check(self, runtime: ScriptAdapterRuntime) -> str:
+        if runtime.mode != "AutoProxy":
+            return "OK-WW 插件仅支持 AutoProxy 模式"
+        return "Pass"
+
+    async def prepare(self, runtime: ScriptAdapterRuntime) -> None:
+        storage_script_config = runtime.get_storage_script_config()
+        await storage_script_config.lock()
+        runtime.storage_script_config = storage_script_config
+        runtime.script_config = await runtime.build_script_model()
+        user_pairs = await runtime.build_user_models()
+        provider = runtime._resolve_provider()
+        user_config = MultipleConfig([provider.user_config_class])
+        await user_config.load(
+            {
+                "instances": [
+                    {"uid": user_id, "type": provider.user_config_class.__name__}
+                    for user_id, _ in user_pairs
+                ],
+                **{
+                    user_id: await model.toDict(if_decrypt=False)
+                    for user_id, model in user_pairs
+                    if isinstance(model, ConfigBase)
+                },
+            }
+        )
+
+        runtime.extra["user_config"] = user_config
+        runtime.script_info.user_list = [
+            UserItem(
+                user_id=user_id,
+                name=_user_name(model if isinstance(model, ConfigBase) else None, user_id),
+                status="等待",
+            )
+            for user_id, model in user_pairs
+            if isinstance(model, ConfigBase) and _user_enabled(model)
+        ]
+
+        game_enabled = bool(_cfg_get(runtime.script_config, "Game", "Enabled", False))
+        runtime.extra["game_manager"] = ProcessManager() if game_enabled else None
+        runtime.extra["temp_path"] = None
+        runtime.extra["script_config_path"] = None
+        runtime.extra["had_original_script_config"] = False
+
+        root_path = str(_cfg_get(runtime.script_config, "Info", "RootPath", "") or "").strip()
+        if root_path:
+            script_config_path = Path(root_path) / _OKWW_REL_CONFIG_DIR
+            temp_path = Path.cwd() / f"data/{runtime.script_info.script_id}/Temp"
+            temp_path.mkdir(parents=True, exist_ok=True)
+            runtime.extra["script_config_path"] = script_config_path
+            runtime.extra["temp_path"] = temp_path
+            if script_config_path.exists():
+                runtime.extra["had_original_script_config"] = True
+                shutil.copytree(script_config_path, temp_path, dirs_exist_ok=True)
+
+    async def finalize(self, runtime: ScriptAdapterRuntime) -> None:
+        await self._restore_script_config_from_temp(runtime)
+        await self._write_back_user_config(runtime)
+        if any(user.status == "异常" for user in runtime.script_info.user_list):
+            runtime.script_info.status = "异常"
+            return
+        runtime.script_info.status = "完成"
+
+    async def on_crash(self, runtime: ScriptAdapterRuntime, error: Exception) -> None:
+        runtime.script_info.status = "异常"
+        logger.exception(f"OK-WW 插件任务出现异常: {error}")
+        await self._restore_script_config_from_temp(runtime)
+        with suppress(Exception):
+            await self._write_back_user_config(runtime)
+        await Config.send_websocket_message(
+            id=runtime.task_info.task_id,
+            type="Info",
+            data={"Error": f"OK-WW 插件任务出现异常: {error}"},
+        )
+
+    def run_auto_proxy(self, runtime: ScriptAdapterRuntime, user_index: int) -> TaskExecuteBase:
+        user_config = runtime.extra.get("user_config")
+        if not isinstance(user_config, MultipleConfig):
+            raise RuntimeError("OK-WW 用户配置未准备完成")
+        inner = AutoProxyTask(
+            script_info=runtime.script_info,
+            script_config=runtime.script_config,
+            user_config=user_config,
+            game_manager=runtime.extra.get("game_manager"),
+        )
+        _ = user_index
+        return _CheckedAutoProxyTask(inner)
+
+    async def _write_back_user_config(self, runtime: ScriptAdapterRuntime) -> None:
+        script_uid = uuid.UUID(runtime.script_info.script_id)
+        script_cfg = Config.ScriptConfig[script_uid]
+        if script_cfg.is_locked:
+            await script_cfg.unlock()
+        user_config = runtime.extra.get("user_config")
+        if not isinstance(user_config, MultipleConfig):
+            return
+        await script_cfg.UserData.load(await user_config.toDict(if_decrypt=False))
+
+    async def _restore_script_config_from_temp(self, runtime: ScriptAdapterRuntime) -> None:
+        temp_path = runtime.extra.get("temp_path")
+        script_config_path = runtime.extra.get("script_config_path")
+        had_original = bool(runtime.extra.get("had_original_script_config"))
+        if not (
+            isinstance(temp_path, Path)
+            and temp_path.exists()
+            and isinstance(script_config_path, Path)
+        ):
+            return
+        if not had_original:
+            logger.info(f"清理任务期写入的 OK-WW 脚本配置目录: {script_config_path}")
+            shutil.rmtree(script_config_path, ignore_errors=True)
+        else:
+            logger.info(f"复原 OK-WW 脚本配置文件: {temp_path}")
+            tmp_dst = script_config_path.with_name(script_config_path.name + ".tmp")
+            shutil.rmtree(tmp_dst, ignore_errors=True)
+            shutil.copytree(temp_path, tmp_dst, dirs_exist_ok=True)
+            shutil.rmtree(script_config_path, ignore_errors=True)
+            tmp_dst.rename(script_config_path)
+        shutil.rmtree(temp_path, ignore_errors=True)
+        with suppress(Exception):
+            await System.kill_process(Path(_cfg_get(runtime.script_config, "Info", "RootPath", "")) / "ok-ww.exe")

--- a/plugins/okww_adapter/src/okww_adapter/config_schema.py
+++ b/plugins/okww_adapter/src/okww_adapter/config_schema.py
@@ -1,0 +1,357 @@
+#   AUTO-MAS: A Multi-Script, Multi-Config Management and Automation Software
+#   Copyright © 2025-2026 AUTO-MAS Team
+#
+#   This file is part of AUTO-MAS.
+#
+#   AUTO-MAS is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of
+#   the License, or (at your option) any later version.
+#
+#   AUTO-MAS is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+#   the GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with AUTO-MAS. If not, see <https://www.gnu.org/licenses/>.
+
+"""
+OK-WW 配置文件 Schema 定义
+
+半自动模式：
+- 字段名 / 类型从 JSON 配置文件值自动推断
+- 中文标签从 ok-ww 安装目录的 .po / .mo / .ts 自动加载
+- 仅下拉 / 多选的可选项列表需在此手工维护
+"""
+
+from __future__ import annotations
+from typing import Any
+from pathlib import Path
+import gettext
+import re
+from xml.etree import ElementTree
+
+
+# ─── OK-WW 翻译文件自动加载 ─────────────────────────────────────────────────
+
+_PO_ENTRY_RE = re.compile(
+    r'^msgid\s+"((?:[^"\\]|\\.)*)"\s*\nmsgstr\s+"((?:[^"\\]|\\.)*)"',
+    re.MULTILINE,
+)
+
+
+def _parse_po_file(po_path: Path) -> dict[str, str]:
+    """解析 .po 翻译文件，返回 {msgid: msgstr} 映射。"""
+    labels: dict[str, str] = {}
+    try:
+        text = po_path.read_text(encoding="utf-8")
+        for match in _PO_ENTRY_RE.finditer(text):
+            msgid = match.group(1)
+            msgstr = match.group(2)
+            if msgid and msgstr:
+                labels[msgid] = msgstr
+    except Exception:
+        pass
+    return labels
+
+
+def _parse_mo_file(mo_path: Path) -> dict[str, str]:
+    """解析 .mo 编译翻译文件，返回 {msgid: msgstr} 映射。"""
+    try:
+        with mo_path.open("rb") as fp:
+            catalog = gettext.GNUTranslations(fp)._catalog
+        return {
+            msgid: msgstr
+            for msgid, msgstr in catalog.items()
+            if isinstance(msgid, str)
+            and msgid
+            and isinstance(msgstr, str)
+            and msgstr
+        }
+    except Exception:
+        return {}
+
+
+def _parse_ts_file(ts_path: Path) -> dict[str, str]:
+    """解析 Qt .ts 翻译文件（ok-script 框架级翻译）。"""
+    labels: dict[str, str] = {}
+    try:
+        root = ElementTree.parse(str(ts_path)).getroot()
+        for message in root.iter("message"):
+            source = message.find("source")
+            translation = message.find("translation")
+            if (
+                source is not None
+                and translation is not None
+                and source.text
+                and translation.text
+                and translation.attrib.get("type") != "unfinished"
+            ):
+                labels[source.text] = translation.text
+    except Exception:
+        pass
+    return labels
+
+
+def load_okww_option_labels(root_path: Path | str) -> dict[str, str]:
+    """从 ok-ww 安装目录自动加载选项的英文→中文翻译映射。
+
+    搜索优先级：ok.mo > ok.po，同时补充 ok-script 框架的 zh_CN.ts。
+    """
+    root = Path(root_path)
+    labels: dict[str, str] = {}
+
+    i18n_candidates = [
+        root / "i18n",
+        root / "_internal" / "i18n",
+        root / "data" / "apps" / "ok-ww" / "repo" / "i18n",
+        root / "data" / "apps" / "ok-ww" / "working" / "i18n",
+    ]
+
+    for i18n_dir in i18n_candidates:
+        mo_file = i18n_dir / "zh_CN" / "LC_MESSAGES" / "ok.mo"
+        if mo_file.is_file():
+            loaded = _parse_mo_file(mo_file)
+            if loaded:
+                labels.update(loaded)
+                break
+
+        po_file = i18n_dir / "zh_CN" / "LC_MESSAGES" / "ok.po"
+        if po_file.is_file():
+            loaded = _parse_po_file(po_file)
+            if loaded:
+                labels.update(loaded)
+                break
+
+    ts_candidates = [
+        root / "ok" / "gui" / "i18n" / "zh_CN.ts",
+        root / "_internal" / "ok" / "gui" / "i18n" / "zh_CN.ts",
+        root / "data" / "apps" / "ok-ww" / "repo" / "ok" / "gui" / "i18n" / "zh_CN.ts",
+    ]
+    for ts_file in ts_candidates:
+        if ts_file.is_file():
+            loaded = _parse_ts_file(ts_file)
+            if loaded:
+                labels.update(loaded)
+                break
+
+    return labels
+
+
+# ─── 通用兜底标签（JSON 中不出现但前端需要） ─────────────────────────────
+
+_FALLBACK_LABELS: dict[str, str] = {
+    "Yes": "是",
+    "No": "否",
+    "Auto": "自动",
+    "None": "无",
+}
+
+
+# ─── 手工维护：下拉 / 多选的可选项列表 ───────────────────────────────────
+#
+# ok-ww 打包后源码不可读，JSON 配置文件只存当前值不存侯选列表，
+# 因此下拉 / 多选字段的选项必须在这里声明。
+# 布尔、整数、文本字段无需声明——自动从 JSON 值推断类型。
+
+SELECT_OPTIONS: dict[str, dict[str, list[str]]] = {
+    # ── 任务配置 ──
+    "DailyTask.json": {
+        "Which to Farm": [
+            "Tacet Suppression", "Forgery Challenge", "Simulation Challenge",
+        ],
+        "Material Selection": [
+            "Resonator EXP", "Weapon EXP", "Shell Credit",
+        ],
+    },
+    "FarmEchoTask.json": {
+        "Teleport to Boss": [
+            "No", "Weekly Challenge", "Boss Challenge",
+        ],
+        "Boss": [
+            "Other", "Hyvatia", "Fallacy of No Return", "Sentry Construct",
+            "Lorelei", "Lioness of Glory", "Nightmare: Hecate",
+            "Fenrico", "Nameless Explorer",
+        ],
+        "Boss Level": ["50", "60", "70", "80"],
+        "Echo Pickup Method": ["Yolo", "Run in Circle", "Walk"],
+    },
+    "NightmareNestTask.json": {
+        "Which to Farm": ["Nightmare Purification", "Tacet Discord Nest"],
+    },
+    "SimulationTask.json": {
+        "Material Selection": [
+            "Resonator EXP", "Weapon EXP", "Shell Credit",
+        ],
+    },
+    # ── 全局配置 ──
+    "Basic Options.json": {
+        "Use DirectML": ["Auto", "Yes", "No"],
+        "Start/Stop": ["None", "F9", "F10", "F11", "F12"],
+        "Blur Algorithm": ["Blur", "Inpaint"],
+    },
+}
+
+
+def _get_select_options(filename: str, field_name: str) -> list[str] | None:
+    """获取指定字段的下拉 / 多选选项列表。"""
+    return SELECT_OPTIONS.get(filename, {}).get(field_name)
+
+
+# ─── 文件注册表 ───────────────────────────────────────────────────────────
+
+CONFIG_GROUPS = {
+    "任务配置": [
+        "DailyTask.json",
+        "MultiAccountDailyTask.json",
+        "FarmEchoTask.json",
+        "AutoRogueTask.json",
+        "ForgeryTask.json",
+        "NightmareNestTask.json",
+        "SimulationTask.json",
+        "TacetTask.json",
+    ],
+    "全局配置": [
+        "Game Hotkey.json",
+        "Character Config.json",
+        "Monthly Card Config.json",
+        "Basic Options.json",
+    ],
+}
+
+CONFIG_DISPLAY_NAMES: dict[str, str] = {
+    "DailyTask.json": "日常一条龙",
+    "MultiAccountDailyTask.json": "多账号一条龙",
+    "FarmEchoTask.json": "刷4C(大世界/副本)",
+    "AutoRogueTask.json": "半自动肉鸽(周常)",
+    "ForgeryTask.json": "凝素领域",
+    "NightmareNestTask.json": "梦魇巢穴",
+    "SimulationTask.json": "模拟领域",
+    "TacetTask.json": "无音区",
+    "Game Hotkey.json": "游戏快捷键",
+    "Character Config.json": "角色设置",
+    "Monthly Card Config.json": "小月卡设置",
+    "Basic Options.json": "基本设置",
+}
+
+TASK_INDEX_MAP: dict[str, int] = {
+    "DailyTask.json": 1,
+    "MultiAccountDailyTask.json": 2,
+    "FarmEchoTask.json": 3,
+    "AutoRogueTask.json": 4,
+    "ForgeryTask.json": 5,
+    "NightmareNestTask.json": 6,
+    "SimulationTask.json": 7,
+    "TacetTask.json": 8,
+}
+
+
+# ─── JSON 字段自动发现 ────────────────────────────────────────────────────
+
+def _infer_field_type(value: Any) -> str:
+    """从 JSON 值推断前端字段类型。"""
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        return "int"
+    if isinstance(value, float):
+        return "float"
+    if isinstance(value, list):
+        return "list"
+    return "string"
+
+
+def _translate(key: str, labels: dict[str, str]) -> str:
+    """查找翻译：ok-ww 标签 > 兜底标签 > 原始 key。"""
+    if key in labels:
+        return labels[key]
+    if key in _FALLBACK_LABELS:
+        return _FALLBACK_LABELS[key]
+    return key
+
+
+def build_fields_for_config(
+    filename: str,
+    json_data: dict[str, Any],
+    option_labels: dict[str, str],
+) -> list[dict[str, Any]]:
+    """从 JSON 数据 + 选项映射 + 翻译标签构建前端字段列表。
+
+    逻辑：
+    1. 遍历 JSON 中的字段 → 根据值推断类型
+    2. 若字段在 SELECT_OPTIONS 中有定义 → 设为 select / list 并附选项
+    3. 若字段在翻译中有映射 → 用翻译作为 label
+    4. SELECT_OPTIONS 中定义但 JSON 中没有的字段 → 也加入（新字段，值为 None）
+    """
+    seen: set[str] = set()
+
+    def _is_internal(name: str) -> bool:
+        """ok-ww 框架内部字段（_enabled 等），不暴露给 MAS 用户编辑。"""
+        return name.startswith("_")
+
+    def make_field(name: str, raw_value: Any) -> dict[str, Any]:
+        seen.add(name)
+        opts = _get_select_options(filename, name)
+
+        if opts is not None:
+            # 下拉或多选
+            field_type = "list" if isinstance(raw_value, list) else "select"
+            return {
+                "name": name,
+                "type": field_type,
+                "label": _translate(name, option_labels),
+                "description": "",
+                "value": raw_value,
+                "options": opts,
+                "min": None,
+                "max": None,
+                "step": None,
+            }
+
+        # 普通字段：从 JSON 值推断类型
+        field_type = _infer_field_type(raw_value)
+        return {
+            "name": name,
+            "type": field_type,
+            "label": _translate(name, option_labels),
+            "description": "",
+            "value": raw_value,
+            "options": None,
+            "min": None,
+            "max": None,
+            "step": None,
+        }
+
+    fields = [
+        make_field(k, v)
+        for k, v in json_data.items()
+        if not _is_internal(k)  # 屏蔽 _enabled 等 ok-ww 框架内部字段
+    ]
+
+    # 补充：SELECT_OPTIONS 中有定义但 JSON 中没有的字段（ok-ww 新增配置项）
+    known_options = SELECT_OPTIONS.get(filename, {})
+    for name in known_options:
+        if name not in seen and not _is_internal(name):
+            fields.append(make_field(name, None))
+
+    return fields
+
+
+# ─── API 辅助函数 ─────────────────────────────────────────────────────────
+
+def get_all_config_info() -> list[dict[str, Any]]:
+    """获取所有配置文件的元信息（用于前端列表展示）。"""
+    result = []
+    for group_name, filenames in CONFIG_GROUPS.items():
+        for filename in filenames:
+            # 字段数量 = JSON 中已有的 + SELECT_OPTIONS 中新增的
+            field_count = len(SELECT_OPTIONS.get(filename, {}))
+            result.append({
+                "filename": filename,
+                "displayName": CONFIG_DISPLAY_NAMES.get(filename, filename),
+                "group": group_name,
+                "taskIndex": TASK_INDEX_MAP.get(filename),
+                "fieldCount": max(field_count, 1),  # 至少 1，避免显示 0
+            })
+    return result

--- a/plugins/okww_adapter/src/okww_adapter/plugin.py
+++ b/plugins/okww_adapter/src/okww_adapter/plugin.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+from pathlib import Path
+from typing import Any
+
+from app.core import Config
+from app.core.script_config_codec import storage_to_form
+from app.models.plugin_script_config import PluginScriptConfig
+from app.plugins import PluginHttpRequest, ScriptAdapterDefinition, ScriptAdapterPlugin
+from app.utils import get_logger
+
+from .adapter import OkwwAdapterHooks
+from .adapter.autoproxy import _OKWW_REL_CONFIG_DIR
+from .config_schema import (
+    build_fields_for_config,
+    get_all_config_info,
+    load_okww_option_labels,
+)
+from .schema import OkwwConfig, OkwwUserConfig
+
+DEFAULT_INSTANCE = {
+    "name": "OK-WW 专项适配",
+    "enabled": True,
+    "config": {},
+}
+
+SCRIPT_ADAPTER_TYPE_KEYS = ("Okww",)
+logger = get_logger("OK-WW 插件适配")
+
+
+def _okww_mas_config_dir(script_id: str, user_id: str) -> Path:
+    script_uid = str(uuid.UUID(str(script_id)))
+    user_uid = str(uuid.UUID(str(user_id)))
+    data_root = (Path.cwd() / "data").resolve()
+    target = (data_root / script_uid / user_uid / "ConfigFile").resolve()
+    if data_root != target and data_root not in target.parents:
+        raise ValueError("非法配置目录路径")
+    return target
+
+
+def _okww_config_file_path(config_dir: Path, filename: str) -> Path:
+    target = (config_dir / filename).resolve()
+    root = config_dir.resolve()
+    if root != target and root not in target.parents:
+        raise ValueError("非法配置文件路径")
+    return target
+
+
+def _read_json_file(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _write_json_file_atomic(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(path.name + ".tmp")
+    tmp_path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    tmp_path.replace(path)
+
+
+def _iter_config_updates(raw: Any) -> list[tuple[str, dict[str, Any]]]:
+    updates: list[tuple[str, dict[str, Any]]] = []
+    if isinstance(raw, dict):
+        for filename, data in raw.items():
+            if isinstance(filename, str) and isinstance(data, dict):
+                updates.append((filename, data))
+        return updates
+    if isinstance(raw, list):
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            filename = item.get("filename")
+            data = item.get("data")
+            if isinstance(filename, str) and isinstance(data, dict):
+                updates.append((filename, data))
+    return updates
+
+
+class Plugin(ScriptAdapterPlugin):
+    """OK-WW script adapter plugin."""
+
+    def build_script_adapters(self) -> list[ScriptAdapterDefinition]:
+        return [
+            ScriptAdapterDefinition(
+                type_key="Okww",
+                display_name="ok-ww脚本",
+                script_model=OkwwConfig,
+                user_model=OkwwUserConfig,
+                hooks_factory=OkwwAdapterHooks,
+                supported_modes=("AutoProxy",),
+                icon="Okww",
+                editor_kind="plugin:okww_adapter",
+                metadata={"framework": "ok-script", "source": "okww_adapter"},
+            )
+        ]
+
+    async def on_start(self) -> None:
+        await super().on_start()
+        self.ctx.server.http(
+            "/okww/configs/list",
+            self._list_configs,
+            methods=("GET", "POST"),
+        )
+        self.ctx.server.http(
+            "/okww/configs/update",
+            self._update_config,
+            methods=("POST",),
+        )
+        self.ctx.server.http(
+            "/okww/configs/batch-update",
+            self._batch_update_configs,
+            methods=("POST",),
+        )
+
+    async def _script_form_config(self, script_id: str) -> dict[str, Any]:
+        script_config = Config.ScriptConfig[uuid.UUID(script_id)]
+        if not isinstance(script_config, PluginScriptConfig):
+            raise ValueError("脚本不是 OK-WW 插件配置")
+        if str(script_config.get("Meta", "PluginTypeKey") or "").strip() != "Okww":
+            raise ValueError("脚本不是 OK-WW 插件配置")
+
+        from app.core.script_types import script_type_registry
+
+        provider = script_type_registry.get("Okww")
+        return await storage_to_form(
+            provider,
+            script_config.get("PluginData", "Config"),
+            "script",
+        )
+
+    async def _script_root_path(self, script_id: str) -> Path | None:
+        config = await self._script_form_config(script_id)
+        root_path = config.get("Info", {}).get("RootPath")
+        if isinstance(root_path, str) and root_path.strip():
+            return Path(root_path)
+        return None
+
+    async def _list_configs(self, request: PluginHttpRequest) -> dict[str, Any]:
+        payload = request.json if isinstance(request.json, dict) else request.query
+        script_id = str(payload.get("script_id") or payload.get("scriptId") or "")
+        user_id = str(payload.get("user_id") or payload.get("userId") or "")
+        if not script_id or not user_id:
+            return {"code": 400, "status": "error", "message": "缺少 script_id 或 user_id"}
+        try:
+            mas_config_dir = _okww_mas_config_dir(script_id, user_id)
+        except ValueError as exc:
+            return {"code": 400, "status": "error", "message": str(exc)}
+
+        try:
+            root_path = await self._script_root_path(script_id)
+        except (KeyError, ValueError) as exc:
+            return {"code": 400, "status": "error", "message": str(exc)}
+        option_labels = load_okww_option_labels(root_path) if root_path else {}
+        okww_configs_dir = root_path / _OKWW_REL_CONFIG_DIR if root_path else None
+
+        need_init = not (
+            mas_config_dir.is_dir()
+            and any(item.is_file() for item in mas_config_dir.rglob("*"))
+        )
+        if need_init and okww_configs_dir and okww_configs_dir.is_dir():
+            mas_config_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(okww_configs_dir, mas_config_dir, dirs_exist_ok=True)
+
+        configs: list[dict[str, Any]] = []
+        for info in get_all_config_info():
+            filename = info["filename"]
+            file_path = mas_config_dir / filename
+            data = _read_json_file(file_path)
+            configs.append(
+                {
+                    **info,
+                    "exists": file_path.is_file(),
+                    "fields": build_fields_for_config(filename, data, option_labels),
+                    "currentData": data,
+                }
+            )
+
+        return {
+            "code": 200,
+            "status": "success",
+            "data": configs,
+            "optionLabels": option_labels,
+            "configPath": str(mas_config_dir),
+        }
+
+    async def _update_config(self, request: PluginHttpRequest) -> dict[str, Any]:
+        payload = request.json if isinstance(request.json, dict) else {}
+        script_id = str(payload.get("script_id") or payload.get("scriptId") or "")
+        user_id = str(payload.get("user_id") or payload.get("userId") or "")
+        filename = str(payload.get("filename") or "")
+        data = payload.get("data")
+        if not script_id or not user_id or not filename or not isinstance(data, dict):
+            return {"code": 400, "status": "error", "message": "请求参数不完整"}
+
+        try:
+            config_dir = _okww_mas_config_dir(script_id, user_id)
+        except ValueError as exc:
+            return {"code": 400, "status": "error", "message": str(exc)}
+        config_dir.mkdir(parents=True, exist_ok=True)
+        file_path = _okww_config_file_path(config_dir, filename)
+        existing_data = _read_json_file(file_path)
+        existing_data.update(data)
+        _write_json_file_atomic(file_path, existing_data)
+        return {"code": 200, "status": "success"}
+
+    async def _batch_update_configs(self, request: PluginHttpRequest) -> dict[str, Any]:
+        payload = request.json if isinstance(request.json, dict) else {}
+        script_id = str(payload.get("script_id") or payload.get("scriptId") or "")
+        user_id = str(payload.get("user_id") or payload.get("userId") or "")
+        configs = payload.get("configs")
+        updates = _iter_config_updates(configs)
+        if not script_id or not user_id or not updates:
+            return {"code": 400, "status": "error", "message": "请求参数不完整"}
+
+        try:
+            config_dir = _okww_mas_config_dir(script_id, user_id)
+        except ValueError as exc:
+            return {"code": 400, "status": "error", "message": str(exc)}
+        config_dir.mkdir(parents=True, exist_ok=True)
+        updated_files: list[str] = []
+        for filename, data in updates:
+            file_path = _okww_config_file_path(config_dir, filename)
+            existing_data = _read_json_file(file_path)
+            existing_data.update(data)
+            _write_json_file_atomic(file_path, existing_data)
+            updated_files.append(filename)
+        return {"code": 200, "status": "success", "data": updated_files}

--- a/plugins/okww_adapter/src/okww_adapter/schema.py
+++ b/plugins/okww_adapter/src/okww_adapter/schema.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from app.plugins.fields import PluginField
+
+
+class PluginConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+class Config(PluginConfig):
+    """Plugin instance config entrypoint."""
+
+
+class OkwwInfoConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    Name: str = PluginField(
+        default="新 OK-WW 脚本",
+        title="脚本名称",
+        json_schema_extra={"size": "half"},
+    )
+    RootPath: str = PluginField(
+        default="",
+        title="ok-ww 路径",
+        placeholder="请选择 ok-ww.exe 所在目录",
+        ui_type="path",
+        path_kind="folder",
+        required=True,
+        json_schema_extra={"size": "large"},
+    )
+
+
+class OkwwGameConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    Enabled: bool = PluginField(
+        default=False,
+        title="启用游戏管理",
+        description="任务开始前可由 MAS 启动鸣潮客户端。",
+        json_schema_extra={"size": "half"},
+    )
+    CloseOnManualStop: bool = PluginField(
+        default=False,
+        title="手动终止时关闭游戏",
+        json_schema_extra={"size": "half"},
+    )
+    Path: str = PluginField(
+        default="",
+        title="鸣潮游戏路径",
+        placeholder="请选择 Client-Win64-Shipping.exe",
+        ui_type="path",
+        path_kind="file",
+        json_schema_extra={"size": "large"},
+    )
+    Arguments: str = PluginField(
+        default="",
+        title="游戏启动参数",
+        json_schema_extra={"size": "large"},
+    )
+    WaitTime: int = PluginField(
+        default=60,
+        title="等待启动时间",
+        min=0,
+        max=9999,
+        json_schema_extra={"size": "half"},
+    )
+
+
+class OkwwRunConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    ProxyTimesLimit: int = PluginField(
+        default=0,
+        title="每日代理次数限制",
+        min=0,
+        max=9999,
+        json_schema_extra={"size": "half"},
+    )
+    RunTimesLimit: int = PluginField(
+        default=1,
+        title="失败重试次数",
+        min=1,
+        max=9999,
+        json_schema_extra={"size": "half"},
+    )
+    RunTimeLimit: int = PluginField(
+        default=60,
+        title="单次运行超时",
+        min=1,
+        max=9999,
+        json_schema_extra={"size": "half"},
+    )
+
+
+class OkwwConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    Info: OkwwInfoConfig = PluginField(
+        default_factory=OkwwInfoConfig,
+        title="基础信息",
+    )
+    Game: OkwwGameConfig = PluginField(
+        default_factory=OkwwGameConfig,
+        title="游戏配置",
+    )
+    Run: OkwwRunConfig = PluginField(
+        default_factory=OkwwRunConfig,
+        title="运行配置",
+    )
+
+
+class OkwwUserInfoConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    Name: str = PluginField(
+        default="新用户",
+        title="用户名称",
+        validator="username",
+        json_schema_extra={"size": "half"},
+    )
+    Status: bool = PluginField(
+        default=True,
+        title="启用用户",
+        json_schema_extra={"size": "half"},
+    )
+    Id: str = PluginField(default="", title="账号", json_schema_extra={"size": "half"})
+    Password: str = PluginField(
+        default="",
+        title="密码",
+        format="password",
+        sensitive=True,
+        json_schema_extra={"size": "half"},
+    )
+    Resource: Literal["官服"] = PluginField(
+        default="官服",
+        title="服务器",
+        json_schema_extra={"size": "half"},
+    )
+    RemainedDay: int = PluginField(
+        default=-1,
+        title="剩余天数",
+        min=-1,
+        max=9999,
+        json_schema_extra={"size": "half"},
+    )
+    Mode: Literal["简洁", "详细"] = PluginField(
+        default="详细",
+        title="配置模式",
+        readonly=True,
+        json_schema_extra={"size": "half"},
+    )
+    IfScriptBeforeTask: bool = PluginField(
+        default=False,
+        title="启用前置脚本",
+        json_schema_extra={"size": "half"},
+    )
+    ScriptBeforeTask: str = PluginField(
+        default="",
+        title="前置脚本",
+        ui_type="path",
+        path_kind="file",
+        json_schema_extra={"size": "large"},
+    )
+    IfScriptAfterTask: bool = PluginField(
+        default=False,
+        title="启用后置脚本",
+        json_schema_extra={"size": "half"},
+    )
+    ScriptAfterTask: str = PluginField(
+        default="",
+        title="后置脚本",
+        ui_type="path",
+        path_kind="file",
+        json_schema_extra={"size": "large"},
+    )
+    Notes: str = PluginField(
+        default="无",
+        title="备注",
+        format="textarea",
+        rows=3,
+        json_schema_extra={"size": "large"},
+    )
+
+
+class OkwwUserTaskConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    TaskIndex: int = PluginField(
+        default=1,
+        title="任务序号",
+        min=1,
+        max=8,
+        help="与 ok-ww 任务列表的 -t 序号一致。",
+        json_schema_extra={"size": "half"},
+    )
+
+
+class OkwwUserDataConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    LastProxyDate: str = PluginField(
+        default="2000-01-01",
+        title="上次代理日期",
+        readonly=True,
+        json_schema_extra={"size": "half"},
+    )
+    ProxyTimes: int = PluginField(
+        default=0,
+        title="今日代理次数",
+        min=0,
+        max=9999,
+        readonly=True,
+        json_schema_extra={"size": "half"},
+    )
+    LastProxyStatus: Literal["未知", "成功", "失败"] = PluginField(
+        default="未知",
+        title="上次代理状态",
+        readonly=True,
+        json_schema_extra={"size": "half"},
+    )
+    LastTaskIndex: int = PluginField(
+        default=0,
+        title="上次任务序号",
+        min=0,
+        max=9999,
+        readonly=True,
+        json_schema_extra={"size": "half"},
+    )
+
+
+class OkwwUserNotifyConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    Enabled: bool = PluginField(default=False, title="启用单独通知")
+    IfSendStatistic: bool = PluginField(default=False, title="发送统计")
+    IfSendMail: bool = PluginField(default=False, title="发送邮件")
+    ToAddress: str = PluginField(default="", title="收件地址")
+    IfServerChan: bool = PluginField(default=False, title="启用 ServerChan")
+    ServerChanKey: str = PluginField(default="", title="ServerChan Key", sensitive=True)
+    CustomWebhooks: dict[str, Any] = PluginField(
+        default="{}",
+        title="自定义 Webhook",
+        ui_type="json",
+        json_type="object",
+    )
+
+
+class OkwwUserConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    Info: OkwwUserInfoConfig = PluginField(
+        default_factory=OkwwUserInfoConfig,
+        title="基础信息",
+    )
+    Task: OkwwUserTaskConfig = PluginField(
+        default_factory=OkwwUserTaskConfig,
+        title="任务配置",
+    )
+    Data: OkwwUserDataConfig = PluginField(
+        default_factory=OkwwUserDataConfig,
+        title="用户数据",
+    )
+    Notify: OkwwUserNotifyConfig = PluginField(
+        default_factory=OkwwUserNotifyConfig,
+        title="单独通知",
+    )


### PR DESCRIPTION
﻿- 将 OK-WW 从内建脚本类型迁到插件适配器，并接入插件用户编辑页的配置编辑入口。
- 收束游戏管理配置：`Game.Enabled` 作为启动/结束关闭总开关，新增手动终止时关闭游戏配置。
- 暂不处理旧配置迁移，减少本轮审阅面。
- 验证：`python -m py_compile`、定点 `eslint`、`git diff --check` 已通过；用户可见配置变化需要补 `res/version.json`。

## Summary by Sourcery

将 OK-WW 从内置脚本类型迁移为插件适配器，并将其配置管理接入到插件用户编辑流程中。

New Features:
- 当使用 `okwwadapter` 插件时，在插件用户编辑页面中展示 OK-WW 配置编辑器。
- 引入可复用的 Okww 配置 API 组合式工具（composable），同时支持内置和插件端点。
- 在实例绑定的脚本引用收集中，为插件脚本适配器提供支持，包括基于 `PluginScriptConfig` 的脚本。

Enhancements:
- 移除内置的 OK-WW 脚本类型提供者，改为使用基于插件的适配器。
- 调整插件管理器的绑定逻辑，使其在传统脚本类型绑定之外，也能识别适配器类型键。
- 为 OK-WW 适配器实现新增初始的 `okww_adapter` 插件包结构和元数据文件。

Documentation:
- 为 `okww_adapter` 插件添加 README 和相关元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Move OK-WW from a built-in script type to a plugin adapter and wire its configuration management into the plugin user edit flow.

New Features:
- Expose OK-WW configuration editor within the plugin user edit page when using the okwwadapter plugin.
- Introduce a reusable Okww configuration API composable that supports both builtin and plugin endpoints.
- Add support for plugin script adapters in instance-bound script reference collection, including PluginScriptConfig-based scripts.

Enhancements:
- Remove the builtin OK-WW script type provider in favor of the plugin-based adapter.
- Adjust plugin manager binding logic to understand adapter type keys alongside traditional script type bindings.
- Add initial okww_adapter plugin package structure and metadata files for the OK-WW adapter implementation.

Documentation:
- Add README and related metadata for the okww_adapter plugin.

</details>