### PR TITLE
[codex] migrate Okww legacy configs to plugin storage

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -148,6 +148,7 @@ class AppConfig(GlobalConfig):
         await self.PlanConfig.connect(self.config_path / "PlanConfig.json")
         await self.ScriptConfig.connect(self.config_path / "ScriptConfig.json")
         await self._migrate_general_scripts_to_plugin_storage()
+        await self._migrate_okww_scripts_to_plugin_storage()
         await self.QueueConfig.connect(self.config_path / "QueueConfig.json")
         await self.ToolsConfig.connect(self.config_path / "ToolsConfig.json")
         await self.PluginConfig.connect(self.config_path / "PluginConfig.json")
@@ -694,6 +695,89 @@ class AppConfig(GlobalConfig):
 
         return is_script_config_compatible_with_type_key(script_config, "General")
 
+    @staticmethod
+    def _is_okww_legacy_script_config(script_config: ConfigBase) -> bool:
+        """Return whether the record is an old host-owned OkwwConfig."""
+
+        from app.models.config import OkwwConfig
+
+        return isinstance(script_config, OkwwConfig)
+
+    @staticmethod
+    def _pick_config_group(
+        data: dict[str, Any],
+        group: str,
+        fields: tuple[str, ...],
+    ) -> dict[str, Any]:
+        source = data.get(group)
+        if not isinstance(source, dict):
+            return {}
+        return {field: source[field] for field in fields if field in source}
+
+    def _okww_legacy_script_payload(self, data: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "Info": self._pick_config_group(data, "Info", ("Name", "RootPath")),
+            "Game": self._pick_config_group(
+                data,
+                "Game",
+                ("Enabled", "Path", "Arguments", "WaitTime"),
+            ),
+            "Run": self._pick_config_group(
+                data,
+                "Run",
+                ("ProxyTimesLimit", "RunTimesLimit", "RunTimeLimit"),
+            ),
+        }
+
+    def _okww_legacy_user_payload(self, data: dict[str, Any]) -> dict[str, Any]:
+        notify = self._pick_config_group(
+            data,
+            "Notify",
+            (
+                "Enabled",
+                "IfSendStatistic",
+                "IfSendMail",
+                "ToAddress",
+                "IfServerChan",
+                "ServerChanKey",
+            ),
+        )
+        custom_webhooks = (
+            data.get("SubConfigsInfo", {})
+            if isinstance(data.get("SubConfigsInfo"), dict)
+            else {}
+        ).get("Notify_CustomWebhooks")
+        if isinstance(custom_webhooks, dict):
+            notify["CustomWebhooks"] = json.dumps(custom_webhooks, ensure_ascii=False)
+
+        return {
+            "Info": self._pick_config_group(
+                data,
+                "Info",
+                (
+                    "Name",
+                    "Status",
+                    "Id",
+                    "Password",
+                    "Resource",
+                    "RemainedDay",
+                    "Mode",
+                    "IfScriptBeforeTask",
+                    "ScriptBeforeTask",
+                    "IfScriptAfterTask",
+                    "ScriptAfterTask",
+                    "Notes",
+                ),
+            ),
+            "Task": self._pick_config_group(data, "Task", ("TaskIndex",)),
+            "Data": self._pick_config_group(
+                data,
+                "Data",
+                ("LastProxyDate", "ProxyTimes", "LastProxyStatus", "LastTaskIndex"),
+            ),
+            "Notify": notify,
+        }
+
     async def _read_general_script_payload(
         self,
         script_uid: uuid.UUID,
@@ -799,6 +883,67 @@ class AppConfig(GlobalConfig):
 
         await self.ScriptConfig.save()
         logger.success("旧通用脚本已迁移到插件脚本容器")
+
+    async def _migrate_okww_scripts_to_plugin_storage(self) -> None:
+        """Move old OkwwConfig records into the plugin storage container.
+
+        This migration is intentionally narrow and temporary: it upgrades old
+        host-owned Okww records to plugin-owned records so the legacy Okww
+        provider fallback can be removed after the migration window.
+        """
+
+        from app.models.plugin_script_config import PluginScriptConfig, PluginUserConfig
+
+        migrate_list = [
+            script_uid
+            for script_uid, script_config in self.ScriptConfig.items()
+            if self._is_okww_legacy_script_config(script_config)
+            and not isinstance(script_config, PluginScriptConfig)
+        ]
+        if not migrate_list:
+            return
+
+        logger.info(f"检测到 {len(migrate_list)} 个旧 Okww 脚本，开始迁移到插件脚本容器")
+
+        for script_uid in migrate_list:
+            legacy_script = self.ScriptConfig[script_uid]
+            script_payload = self._okww_legacy_script_payload(
+                await legacy_script.toDict(if_decrypt=False)
+            )
+
+            plugin_script = PluginScriptConfig()
+            await plugin_script.set("Meta", "PluginTypeKey", "Okww")
+            await plugin_script.set("Info", "Name", legacy_script.get("Info", "Name"))
+            await plugin_script.set(
+                "PluginData",
+                "Config",
+                json.dumps(script_payload, ensure_ascii=False),
+            )
+
+            for user_uid, legacy_user in legacy_script.UserData.items():
+                user_payload = self._okww_legacy_user_payload(
+                    await legacy_user.toDict(if_decrypt=False)
+                )
+                plugin_user = PluginUserConfig()
+                await plugin_user.set("Meta", "PluginTypeKey", "Okww")
+                await plugin_user.set("Info", "Name", legacy_user.get("Info", "Name"))
+                await plugin_user.set(
+                    "PluginData",
+                    "Config",
+                    json.dumps(user_payload, ensure_ascii=False),
+                )
+                plugin_script.UserData.order.append(user_uid)
+                plugin_script.UserData.data[user_uid] = plugin_user
+
+            if self.ScriptConfig.file is not None:
+                await plugin_script.add_save_method(self.ScriptConfig.save)
+            for save_method in self.ScriptConfig._save_methods:
+                await plugin_script.add_save_method(save_method)
+
+            self.ScriptConfig.data[script_uid] = plugin_script
+
+        await self.ScriptConfig.save()
+        logger.success("旧 Okww 脚本已迁移到插件脚本容器")
 
     async def add_script(
         self,

--- a/frontend/src/utils/scriptRegistry.ts
+++ b/frontend/src/utils/scriptRegistry.ts
@@ -74,7 +74,6 @@ export const BUILTIN_SCRIPT_TYPES = new Set([
   'MaaEnd',
   'M9A',
   'MaaFW',
-  'Okww',
   'HSR',
 ])
 
@@ -128,7 +127,6 @@ const BUILTIN_EDITOR_SEGMENTS: Record<string, string> = {
   'builtin:maaend': 'maaend',
   'builtin:m9a': 'm9a',
   'builtin:maafw': 'maafw',
-  'builtin:okww': 'okww',
   'builtin:hsr': 'hsr',
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
 ]
 plugins = [
     "auto-mas-core",
+    "automas_plugin_okww_adapter",
 ]
 
 [tool.auto-mas.plugin-bootstrap]
@@ -57,6 +58,7 @@ package = false
 [tool.uv.workspace]
 members = [
     "plugins/auto_mas_core",
+    "plugins/okww_adapter",
 ]
 exclude = [
     "plugins/pypi",
@@ -65,3 +67,4 @@ exclude = [
 
 [tool.uv.sources]
 "auto-mas-core" = { workspace = true }
+"automas_plugin_okww_adapter" = { workspace = true }

--- a/tests/plugins/test_okww_plugin_migration.py
+++ b/tests/plugins/test_okww_plugin_migration.py
@@ -1,0 +1,60 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from app.core.config import AppConfig
+from app.models.config import OkwwConfig, OkwwUserConfig
+from app.models.plugin_script_config import PluginScriptConfig, PluginUserConfig
+
+
+class OkwwPluginMigrationTest(unittest.IsolatedAsyncioTestCase):
+    async def test_migrates_legacy_okww_config_to_plugin_storage(self) -> None:
+        app_config = AppConfig()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root_path = str(Path(temp_dir) / "okww")
+            normalized_root_path = Path(root_path).resolve().as_posix()
+            game_path = str(Path(temp_dir) / "Client.exe")
+            await app_config.ScriptConfig.connect(Path(temp_dir) / "ScriptConfig.json")
+            script_uid, script_config = await app_config.ScriptConfig.add(OkwwConfig)
+            await script_config.set("Info", "Name", "旧 Okww")
+            await script_config.set("Info", "RootPath", root_path)
+            await script_config.set("Game", "Enabled", True)
+            await script_config.set("Game", "LaunchBeforeTask", True)
+            await script_config.set("Game", "Path", game_path)
+            await script_config.set("Run", "RunTimesLimit", 3)
+
+            user_uid, user_config = await script_config.UserData.add(OkwwUserConfig)
+            await user_config.set("Info", "Name", "账号 A")
+            await user_config.set("Info", "Id", "user-a")
+            await user_config.set("Task", "TaskIndex", 5)
+            await user_config.set("Data", "LastProxyStatus", "成功")
+
+            await app_config._migrate_okww_scripts_to_plugin_storage()
+
+            migrated_script = app_config.ScriptConfig[script_uid]
+            self.assertIsInstance(migrated_script, PluginScriptConfig)
+            self.assertEqual(migrated_script.get("Meta", "PluginTypeKey"), "Okww")
+            self.assertEqual(migrated_script.UserData.order, [user_uid])
+
+            script_payload = json.loads(migrated_script.get("PluginData", "Config"))
+            self.assertEqual(script_payload["Info"]["Name"], "旧 Okww")
+            self.assertEqual(script_payload["Info"]["RootPath"], normalized_root_path)
+            self.assertTrue(script_payload["Game"]["Enabled"])
+            self.assertNotIn("LaunchBeforeTask", script_payload["Game"])
+            self.assertEqual(script_payload["Run"]["RunTimesLimit"], 3)
+
+            migrated_user = migrated_script.UserData[user_uid]
+            self.assertIsInstance(migrated_user, PluginUserConfig)
+            self.assertEqual(migrated_user.get("Meta", "PluginTypeKey"), "Okww")
+
+            user_payload = json.loads(migrated_user.get("PluginData", "Config"))
+            self.assertEqual(user_payload["Info"]["Name"], "账号 A")
+            self.assertEqual(user_payload["Info"]["Id"], "user-a")
+            self.assertEqual(user_payload["Task"]["TaskIndex"], 5)
+            self.assertEqual(user_payload["Data"]["LastProxyStatus"], "成功")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary
- migrate legacy Okww script/user configs into PluginScriptConfig storage on startup
- route Okww records through the plugin editor instead of builtin fallbacks
- include okww_adapter in the plugin workspace and cover migration with a unit test

## Checks
- python scripts/sync_plugin_workspace.py --check
- python -m unittest discover tests
- ./node_modules/.bin/tsc.cmd -p tsconfig.electron.json --noEmit
- ./node_modules/.bin/vue-tsc.cmd --noEmit -p tsconfig.app.json (blocked by existing frontend/src/views/Plugin.vue:48 syntax error)

## Summary by Sourcery

将传统的 Okww 脚本和用户配置迁移到基于插件的存储中，并将 Okww 视为插件而不是内置脚本类型。

新功能：
- 引入启动迁移流程，将主机持有的 `OkwwConfig` 和 `OkwwUserConfig` 记录转换为 `PluginScriptConfig` 和 `PluginUserConfig` 条目。

改进：
- 添加辅助工具，用于将 Okww 脚本和用户负载规范化并序列化为插件配置数据。
- 在 Python 插件列表和工作区配置中注册 Okww 适配器插件，使其参与插件系统。

构建：
- 更新 `pyproject` 插件和工作区设置，将 Okww 适配器插件包含在内。

测试：
- 添加一个异步单元测试，用于覆盖将传统 Okww 脚本和用户数据迁移到插件存储的流程，并验证负载内容和插件元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate legacy Okww script and user configurations into plugin-based storage and treat Okww as a plugin rather than a built-in script type.

New Features:
- Introduce startup migration that converts host-owned OkwwConfig and OkwwUserConfig records into PluginScriptConfig and PluginUserConfig entries.

Enhancements:
- Add helpers to normalize and serialize Okww script and user payloads into plugin configuration data.
- Register the Okww adapter plugin in the Python plugin list and workspace configuration so it participates in the plugin system.

Build:
- Update pyproject plugin and workspace settings to include the Okww adapter plugin.

Tests:
- Add an asynchronous unit test that covers migrating legacy Okww script and user data to plugin storage and validates payload content and plugin metadata.

</details>

新特性：
- 引入启动迁移逻辑，将宿主拥有的 `OkwwConfig` 和 `OkwwUserConfig` 记录转换为插件脚本容器中的 `PluginScriptConfig` 和 `PluginUserConfig` 条目。

增强内容：
- 添加辅助例程，用于将 Okww 脚本和用户负载规范化并序列化为插件配置数据。
- 在 Python 项目的插件列表和工作空间配置中加入 Okww 适配器插件。

测试：
- 添加一个异步单元测试，覆盖将传统 Okww 脚本和用户迁移到插件存储的场景，并验证负载内容和插件元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将传统的 Okww 脚本和用户配置迁移到基于插件的存储中，并将 Okww 视为插件而不是内置脚本类型。

新功能：
- 引入启动迁移流程，将主机持有的 `OkwwConfig` 和 `OkwwUserConfig` 记录转换为 `PluginScriptConfig` 和 `PluginUserConfig` 条目。

改进：
- 添加辅助工具，用于将 Okww 脚本和用户负载规范化并序列化为插件配置数据。
- 在 Python 插件列表和工作区配置中注册 Okww 适配器插件，使其参与插件系统。

构建：
- 更新 `pyproject` 插件和工作区设置，将 Okww 适配器插件包含在内。

测试：
- 添加一个异步单元测试，用于覆盖将传统 Okww 脚本和用户数据迁移到插件存储的流程，并验证负载内容和插件元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate legacy Okww script and user configurations into plugin-based storage and treat Okww as a plugin rather than a built-in script type.

New Features:
- Introduce startup migration that converts host-owned OkwwConfig and OkwwUserConfig records into PluginScriptConfig and PluginUserConfig entries.

Enhancements:
- Add helpers to normalize and serialize Okww script and user payloads into plugin configuration data.
- Register the Okww adapter plugin in the Python plugin list and workspace configuration so it participates in the plugin system.

Build:
- Update pyproject plugin and workspace settings to include the Okww adapter plugin.

Tests:
- Add an asynchronous unit test that covers migrating legacy Okww script and user data to plugin storage and validates payload content and plugin metadata.

</details>

</details>