### PR TITLE
[codex] 收紧插件事件异步分发

### DIFF
--- a/app/plugins/event_bus.py
+++ b/app/plugins/event_bus.py
@@ -77,12 +77,7 @@ class EventBus:
             ValueError: `scope` 不在允许值集合时抛出。
             ValueError: `error_policy` 不在允许值集合且不为 None 时抛出。
         """
-        if not isinstance(event, str):
-            raise TypeError("event 必须是字符串")
-
-        normalized_event = event.strip()
-        if not normalized_event:
-            raise ValueError("event 不能为空字符串")
+        normalized_event = self._normalize_event(event)
 
         if not callable(handler):
             raise TypeError("handler 必须可调用")
@@ -139,7 +134,9 @@ class EventBus:
         if handler is None and listener_id is None:
             raise ValueError("off 需要提供 handler 或 listener_id")
 
-        handlers = self._handlers.get(event)
+        normalized_event = self._normalize_event(event)
+
+        handlers = self._handlers.get(normalized_event)
         if not handlers:
             return
 
@@ -154,9 +151,9 @@ class EventBus:
                 filtered.append(item)
 
         if filtered:
-            self._handlers[event] = filtered
+            self._handlers[normalized_event] = filtered
         else:
-            self._handlers.pop(event, None)
+            self._handlers.pop(normalized_event, None)
 
     def off_by_instance(self, instance_id: str) -> None:
         """
@@ -206,14 +203,24 @@ class EventBus:
             None: 无返回值。
 
         Raises:
+            ValueError: `scope` 不在允许值集合时抛出。
+            ValueError: `error_policy` 不在允许值集合时抛出。
             ValueError: `scope` 为 instance 且 `source_instance_id` 为空时抛出。
             EventDispatchError: 在 raise 策略下监听器执行失败时抛出聚合异常。
         """
+        normalized_event = self._normalize_event(event)
+
+        if scope not in {"global", "instance"}:
+            raise ValueError("scope 仅支持 global 或 instance")
+
+        if error_policy not in {"continue", "raise"}:
+            raise ValueError("error_policy 仅支持 continue 或 raise")
+
         if scope == "instance" and not source_instance_id:
             raise ValueError("instance 作用域事件必须提供 source_instance_id")
 
         async with self._lock:
-            snapshot = list(self._handlers.get(event, []))
+            snapshot = list(self._handlers.get(normalized_event, []))
 
         selected = [
             item
@@ -255,8 +262,19 @@ class EventBus:
 
         if errors:
             raise EventDispatchError(
-                f"事件分发失败: event={event}, count={len(errors)}"
+                f"事件分发失败: event={normalized_event}, count={len(errors)}"
             )
+
+    @staticmethod
+    def _normalize_event(event: str) -> str:
+        if not isinstance(event, str):
+            raise TypeError("event 必须是字符串")
+
+        normalized_event = event.strip()
+        if not normalized_event:
+            raise ValueError("event 不能为空字符串")
+
+        return normalized_event
 
     async def _invoke_handler(
         self,

--- a/app/plugins/event_factory.py
+++ b/app/plugins/event_factory.py
@@ -94,29 +94,6 @@ class PluginEventFactory:
         return payload
 
     @staticmethod
-    def _emit_payload(*, event: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        同步桥接发送已构建好的事件载荷。
-
-        Args:
-            event (str): 事件名。
-            payload (Dict[str, Any]): 事件载荷。
-
-        Returns:
-            Dict[str, Any]: 原始事件载荷。
-        """
-        try:
-            from app.core import PluginManager
-
-            PluginManager.emit(event, payload)
-        except Exception as e:
-            logger.warning(
-                f"插件事件广播失败: event={event}, source={payload.get('source')}, error={e}"
-            )
-
-        return payload
-
-    @staticmethod
     def build_envelope(
         *,
         event: str,
@@ -169,31 +146,6 @@ class PluginEventFactory:
 
         payload = PluginEventFactory.build_envelope(event=event, source=source, data=data)
         return await PluginEventFactory._emit_payload_async(event=event, payload=payload)
-
-    @staticmethod
-    def emit_event(
-        *,
-        event: str,
-        source: str,
-        data: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
-        """
-        构建并发送通用事件（同步桥接）。
-
-        Args:
-            event (str): 事件名。
-            source (str): 事件来源标识。
-            data (Optional[Dict[str, Any]]): 可选业务数据字典。
-
-        Returns:
-            Dict[str, Any]: 已发送的事件载荷。
-        """
-        if not is_valid_source(source):
-            logger.warning(f"事件来源格式不规范: source={source}, event={event}")
-
-        payload = PluginEventFactory.build_envelope(event=event, source=source, data=data)
-        return PluginEventFactory._emit_payload(event=event, payload=payload)
-
     @staticmethod
     def build_script_payload(
         *,
@@ -296,55 +248,3 @@ class PluginEventFactory:
             data=data,
         )
         return await PluginEventFactory._emit_payload_async(event=event, payload=payload)
-
-    @staticmethod
-    def emit_script_event(
-        *,
-        event: str,
-        source: str,
-        task_id: Optional[str] = None,
-        script_id: Optional[str] = None,
-        script_name: Optional[str] = None,
-        mode: Optional[str] = None,
-        status: Optional[str] = None,
-        error: Optional[str] = None,
-        result: Optional[str] = None,
-        data: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
-        """
-        构建并发送脚本领域事件（同步桥接）。
-
-        Args:
-            event (str): 事件名。
-            source (str): 事件来源标识。
-            task_id (Optional[str]): 任务 ID。
-            script_id (Optional[str]): 脚本 ID。
-            script_name (Optional[str]): 脚本名称。
-            mode (Optional[str]): 运行模式。
-            status (Optional[str]): 状态信息。
-            error (Optional[str]): 错误信息。
-            result (Optional[str]): 结果信息。
-            data (Optional[Dict[str, Any]]): 可选业务数据字典。
-
-        Returns:
-            Dict[str, Any]: 已发送的脚本事件载荷。
-        """
-        if not is_valid_source(source):
-            logger.warning(f"脚本事件来源格式不规范: source={source}, event={event}")
-
-        if not is_script_event(event):
-            logger.warning(f"非标准脚本事件名: event={event}")
-
-        payload = PluginEventFactory.build_script_payload(
-            event=event,
-            source=source,
-            task_id=task_id,
-            script_id=script_id,
-            script_name=script_name,
-            mode=mode,
-            status=status,
-            error=error,
-            result=result,
-            data=data,
-        )
-        return PluginEventFactory._emit_payload(event=event, payload=payload)

--- a/app/plugins/manager.py
+++ b/app/plugins/manager.py
@@ -1170,30 +1170,6 @@ class _PluginManager:
         """
         await self.events.emit(event, payload, **kwargs)
 
-    def emit(self, event: str, payload: Any = None, **kwargs: Any) -> None:
-        """
-        同步桥接方式广播事件。
-
-        该方法用于过渡期兼容：
-        - 若存在运行中的事件循环，则创建后台任务异步发送。
-        - 若不存在运行中的事件循环，则直接 `asyncio.run` 完成发送。
-
-        Args:
-            event (str): 事件名。
-            payload (Any): 事件载荷，默认为 None。
-            **kwargs (Any): 透传给事件总线的附加参数。
-
-        Returns:
-            None: 无返回值。
-        """
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            asyncio.run(self.emit_async(event, payload, **kwargs))
-            return
-
-        loop.create_task(self.emit_async(event, payload, **kwargs))
-
     def list_plugins(self) -> Dict[str, str]:
         """
         列出当前已加载插件实例及其状态。

--- a/tests/plugins/test_event_bus.py
+++ b/tests/plugins/test_event_bus.py
@@ -111,6 +111,17 @@ class EventBusTest(unittest.TestCase):
         self._run(scenario())
         self.assertEqual(hits, [])
 
+    def test_off_normalizes_event_name(self) -> None:
+        hits: list[int] = []
+
+        async def scenario():
+            listener_id = self.bus.on(" task.start ", lambda _: hits.append(1))
+            self.bus.off(" task.start ", listener_id=listener_id)
+            await self.bus.emit("task.start", {})
+
+        self._run(scenario())
+        self.assertEqual(hits, [])
+
     def test_off_by_instance_unbinds_all(self) -> None:
         hits: list[int] = []
 
@@ -167,6 +178,28 @@ class EventBusTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             self._run(scenario())
+
+    def test_emit_rejects_invalid_scope(self) -> None:
+        async def scenario():
+            await self.bus.emit("task.start", {}, scope="bad")
+
+        with self.assertRaises(ValueError):
+            self._run(scenario())
+
+    def test_emit_rejects_invalid_error_policy_before_dispatch(self) -> None:
+        hits: list[int] = []
+
+        def bad_handler(_):
+            hits.append(1)
+            raise RuntimeError("boom")
+
+        async def scenario():
+            self.bus.on("task.start", bad_handler)
+            await self.bus.emit("task.start", {}, error_policy="bad")
+
+        with self.assertRaises(ValueError):
+            self._run(scenario())
+        self.assertEqual(hits, [])
 
 
 if __name__ == "__main__":

--- a/tests/plugins/test_plugin_event_flow.py
+++ b/tests/plugins/test_plugin_event_flow.py
@@ -1,0 +1,64 @@
+import asyncio
+import unittest
+from typing import Any, Callable
+
+from app.core.task_manager import Task, TaskInfo
+from app.models.task import ScriptItem
+from app.plugins import PluginEventNames, PluginManager
+
+
+class PluginEventFlowTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.listener_ids: list[tuple[str, str]] = []
+
+    async def asyncTearDown(self) -> None:
+        for event, listener_id in self.listener_ids:
+            PluginManager.off(event, listener_id=listener_id)
+
+    def _listen_once(
+        self,
+        event: str,
+        handler: Callable[[dict[str, Any]], Any],
+    ) -> None:
+        listener_id = PluginManager.on(event, handler, once=True)
+        self.listener_ids.append((event, listener_id))
+
+    async def test_task_start_reaches_plugin_event_listener(self) -> None:
+        received: list[dict[str, Any]] = []
+        received_event = asyncio.Event()
+
+        async def handler(payload: dict[str, Any]) -> None:
+            received.append(payload)
+            received_event.set()
+
+        self._listen_once(PluginEventNames.TASK_START, handler)
+
+        task_info = TaskInfo(
+            mode="ScriptConfig",
+            task_id="task-1",
+            queue_id=None,
+            script_id="script-1",
+            user_id="user-1",
+            script_list=[
+                ScriptItem(
+                    script_id="script-1",
+                    name="Demo Script",
+                    status="等待",
+                )
+            ],
+        )
+
+        await Task(task_info)._emit_task_start()
+        await asyncio.wait_for(received_event.wait(), timeout=1)
+
+        payload = received[0]
+        self.assertEqual(payload["event"], PluginEventNames.TASK_START)
+        self.assertEqual(payload["source"], "core.task_manager")
+        self.assertEqual(payload["data"]["task_id"], "task-1")
+        self.assertEqual(payload["data"]["script_id"], "script-1")
+        self.assertEqual(payload["data"]["primary_script_name"], "Demo Script")
+        self.assertIn("stop_task", payload["data"]["actions"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- 报错点整理：插件事件分发已改为纯异步后，同步桥接入口仍会造成调用语义不一致；事件名空白未在 `off`/`emit` 路径统一归一；`emit` 的 `scope` 和 `error_policy` 缺少派发前校验。
- 修复：移除同步事件桥接入口，统一通过 `emit_async` 路径发送；复用事件名归一逻辑，并在派发前拒绝非法作用域和错误策略。
- 影响：核心任务事件仍可到达插件监听器，异常策略在分发前稳定失败，避免非法参数触发监听器副作用。
- 验证：`python -m pytest tests -q`；`python -m compileall -q app tests plugins`。

## Summary by Sourcery

移除同步插件事件分发路径，并对事件总线分发参数实施更严格的校验。

新特性：
- 新增端到端测试，用于验证核心任务启动事件通过异步事件流传递到插件监听器。

缺陷修复：
- 确保在事件总线上 `on`、`off` 和 `emit` 操作中事件名称以一致的方式进行标准化。
- 在事件发射前拒绝无效的 `scope` 和 `error_policy` 值，防止处理程序在不支持的选项下运行。

改进：
- 通过在插件管理器和事件工厂中仅依赖异步发射简化插件事件处理。
- 将事件名称标准化提取为事件总线上共享的辅助方法，以避免重复逻辑。

测试：
- 扩展事件总线测试，以覆盖使用标准化事件名称的 `off` 行为，以及对 `scope` 和 `error_policy` 的发射前校验。
- 新增独立的插件事件流异步测试套件，以验证任务生命周期事件能携带预期载荷到达插件监听器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove synchronous plugin event dispatch paths and enforce stricter validation for event bus dispatch parameters.

New Features:
- Add an end-to-end test to verify core task start events are delivered to plugin listeners via the async event flow.

Bug Fixes:
- Ensure event names are normalized consistently across on, off, and emit operations in the event bus.
- Reject invalid scope and error_policy values in event emission before dispatch to prevent handlers from running with unsupported options.

Enhancements:
- Simplify plugin event handling by relying solely on async emission in the plugin manager and event factory.
- Factor out event name normalization into a shared helper on the event bus to avoid duplicated logic.

Tests:
- Expand event bus tests to cover off behavior with normalized event names and pre-dispatch validation of scope and error_policy.
- Add an isolated async test suite for plugin event flow to validate that task lifecycle events reach plugin listeners with the expected payload.

</details>