### PR TITLE
[codex] fix websocket sleep resume recovery

### DIFF
--- a/app/api/core.py
+++ b/app/api/core.py
@@ -95,11 +95,7 @@ async def connect_websocket(websocket: WebSocket):
     Config.websocket = session
     asyncio.create_task(TaskManager.start_startup_queue())
     await session.wait_closed()
-
-    if is_backend_dev_mode():
-        logger.warning("后端开发模式下检测到 WS 断链，跳过 KillSelf 自动退出")
-    else:
-        await System.set_power("KillSelf", from_frontend=True)
+    logger.warning("主 WebSocket 已断开，等待前端重新连接")
 
 
 @ws_command("core.close")

--- a/app/core/task_manager.py
+++ b/app/core/task_manager.py
@@ -550,6 +550,8 @@ class _TaskManager:
 
         self.task_info: Dict[uuid.UUID, TaskInfo] = {}
         self.task_handler: Dict[uuid.UUID, Task] = {}
+        self._startup_queue_started = False
+        self._startup_queue_running = False
 
     async def add_task(
         self,
@@ -681,22 +683,39 @@ class _TaskManager:
     async def start_startup_queue(self):
         """开始运行启动时运行的调度队列"""
 
-        await asyncio.sleep(10)
+        if self._startup_queue_started:
+            logger.info("启动时任务已触发，跳过重复运行")
+            return
+        if self._startup_queue_running:
+            logger.info("启动时任务正在等待运行，跳过重复触发")
+            return
 
-        logger.info("开始运行启动时任务")
-        for uid, queue in Config.QueueConfig.items():
+        self._startup_queue_running = True
 
-            if queue.get("Info", "StartUpEnabled"):
-                logger.info(f"启动时需要运行的队列：{uid}")
-                await TaskManager.add_task(
-                    "AutoProxy",
-                    str(uid),
-                    new_task_info={
-                        "queueId": str(uid),
-                        "taskName": f"队列 - {queue.get('Info', 'Name')}",
-                        "taskType": "启动时代理",
-                    },
-                )
+        try:
+            await asyncio.sleep(10)
+
+            if Config.websocket is None:
+                logger.info("主 WebSocket 已断开，启动时任务等待下次连接后运行")
+                return
+
+            self._startup_queue_started = True
+            logger.info("开始运行启动时任务")
+            for uid, queue in Config.QueueConfig.items():
+
+                if queue.get("Info", "StartUpEnabled"):
+                    logger.info(f"启动时需要运行的队列：{uid}")
+                    await TaskManager.add_task(
+                        "AutoProxy",
+                        str(uid),
+                        new_task_info={
+                            "queueId": str(uid),
+                            "taskName": f"队列 - {queue.get('Info', 'Name')}",
+                            "taskType": "启动时代理",
+                        },
+                    )
+        finally:
+            self._startup_queue_running = False
 
         logger.success("启动时任务开始运行")
 

--- a/frontend/electron/services/backendService.ts
+++ b/frontend/electron/services/backendService.ts
@@ -70,6 +70,11 @@ export class BackendService {
     this.resetStartupLogs()
 
     try {
+      const shouldStartNewBackend = await this.prepareUntrackedBackendForStart()
+      if (!shouldStartNewBackend) {
+        return { success: true }
+      }
+
       const venvPythonExe = path.join(this.appRoot, '.venv', 'Scripts', 'python.exe')
       const portablePythonExe = path.join(this.appRoot, 'environment', 'python', 'python.exe')
       const pythonExe = options?.pythonPath || venvPythonExe
@@ -139,6 +144,86 @@ export class BackendService {
 
       return { success: false, error: errorMsg, logs: startupLogs }
     }
+  }
+
+  private async prepareUntrackedBackendForStart(): Promise<boolean> {
+    const apiEndpoint = this.mirrorService.getApiEndpoint('local')
+    const metaUrl = `${apiEndpoint}/api/core/ws_meta`
+    const closeUrl = `${apiEndpoint}/api/core/close`
+
+    try {
+      logger.info(`启动前检查旧后端: ${metaUrl}`)
+      const metaResponse = await this.fetchWithTimeout(metaUrl, { method: 'GET' }, 3000)
+      if (!metaResponse.ok) {
+        return true
+      }
+
+      const meta = (await metaResponse.json()) as { devMode?: boolean }
+      if (meta.devMode) {
+        logger.info('检测到开发模式旧后端，复用现有后端进程')
+        return false
+      }
+    } catch (error) {
+      const errorMsg = error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+      logger.debug(`启动前未发现旧后端: ${errorMsg}`)
+      return true
+    }
+
+    logger.info(`检测到生产模式旧后端，尝试通过 ${closeUrl} 关闭`)
+    const closeResponse = await this.fetchWithTimeout(
+      closeUrl,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+      5000
+    )
+    if (!closeResponse.ok) {
+      throw new Error(`旧后端关闭请求返回错误: ${closeResponse.status}`)
+    }
+
+    const closed = await this.waitForBackendUnavailable(metaUrl, 5000)
+    if (!closed) {
+      throw new Error('旧后端关闭超时，取消启动新后端以避免端口冲突')
+    }
+    return true
+  }
+
+  private async fetchWithTimeout(
+    url: string,
+    init: RequestInit,
+    timeoutMs: number
+  ): Promise<Response> {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), timeoutMs)
+
+    try {
+      return await fetch(url, {
+        ...init,
+        signal: controller.signal,
+      })
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+
+  private async waitForBackendUnavailable(metaUrl: string, timeoutMs: number): Promise<boolean> {
+    const startedAt = Date.now()
+
+    while (Date.now() - startedAt < timeoutMs) {
+      try {
+        const response = await this.fetchWithTimeout(metaUrl, { method: 'GET' }, 1000)
+        if (!response.ok) {
+          return true
+        }
+      } catch {
+        return true
+      }
+      await new Promise(resolve => setTimeout(resolve, 500))
+    }
+    return false
   }
 
   /**

--- a/frontend/electron/services/dependencyService.ts
+++ b/frontend/electron/services/dependencyService.ts
@@ -205,8 +205,38 @@ export class DependencyService {
       return false
     }
 
+    if (!this.ensureVenvPythonPathConfig()) {
+      return false
+    }
+
     const sitePackagesPath = path.join(this.venvPath, 'Lib', 'site-packages')
     return fs.existsSync(sitePackagesPath) && fs.readdirSync(sitePackagesPath).length > 0
+  }
+
+  private ensureVenvPythonPathConfig(): boolean {
+    try {
+      const sourceDir = path.dirname(this.pythonExe)
+      const sourceName = fs.readdirSync(sourceDir).find(name => /^python\d+._pth$/i.test(name))
+
+      if (!sourceName) {
+        return true
+      }
+
+      const sourcePath = path.join(sourceDir, sourceName)
+      const targetPath = path.join(path.dirname(this.venvPythonExe), sourceName)
+      const sourceContent = fs.readFileSync(sourcePath, 'utf-8')
+      const targetContent = fs.existsSync(targetPath) ? fs.readFileSync(targetPath, 'utf-8') : null
+
+      if (targetContent !== sourceContent) {
+        fs.copyFileSync(sourcePath, targetPath)
+        logger.info(`已同步虚拟环境 Python 路径配置: ${targetPath}`)
+      }
+
+      return true
+    } catch (error) {
+      logger.warn(`同步虚拟环境 Python 路径配置失败: ${error}`)
+      return false
+    }
   }
 
   private loadHash(): string | null {

--- a/frontend/electron/services/repositoryService.ts
+++ b/frontend/electron/services/repositoryService.ts
@@ -651,6 +651,8 @@ export class RepositoryService {
       'res',
       'scripts',
       'mas',
+      'plugins/auto_mas_core',
+      'plugins/okww_adapter',
       'main.py',
       'pyproject.toml',
       'requirements.txt',

--- a/frontend/electron/utils/processManager.ts
+++ b/frontend/electron/utils/processManager.ts
@@ -27,7 +27,6 @@ export async function getRelatedProcesses(): Promise<ProcessInfo[]> {
     const psCommand = `
       Get-CimInstance Win32_Process | Where-Object {
         $_.Name -eq 'python.exe' -or 
-        $_.Name -eq 'AUTO-MAS.exe' -or 
         ($_.CommandLine -ne $null -and $_.CommandLine -like '*main.py*')
       } | Select-Object ProcessId, Name, CommandLine | ConvertTo-Json -Compress
     `.replace(/\n/g, ' ')
@@ -65,9 +64,7 @@ export async function getRelatedProcesses(): Promise<ProcessInfo[]> {
 
             if (
               pid > 0 &&
-              (commandLine.includes(pythonExePath) ||
-                commandLine.includes('main.py') ||
-                name === 'AUTO-MAS.exe')
+              (commandLine.includes(pythonExePath) || commandLine.includes('main.py'))
             ) {
               processes.push({ pid, name, commandLine })
             }

--- a/frontend/src/composables/useWebSocket.ts
+++ b/frontend/src/composables/useWebSocket.ts
@@ -38,13 +38,13 @@ if (window.electronAPI?.getApiEndpoint) {
 const HEARTBEAT_INTERVAL = 30000 // 30秒心跳间隔，与后端保持一致
 const HEARTBEAT_TIMEOUT = 45000 // 45秒超时，给网络延迟留够时间
 const BACKEND_CHECK_INTERVAL = 6000 // 6秒检查间隔
-const MAX_RESTART_ATTEMPTS = 3
+const MAX_BACKEND_RESTART_ATTEMPTS = 3
 const RESTART_DELAY = 2000
 const MAX_QUEUE_SIZE = 50 // 每个 ID 或全局 type 队列最大条数
 const MESSAGE_TTL = 60000 // 60 秒过期
 
 // WebSocket重连相关配置
-const MAX_WS_RECONNECT_ATTEMPTS = 5 // WebSocket最大重连尝试次数
+const WS_RECONNECT_CYCLE_ATTEMPTS = 5 // 每轮 WebSocket 重连尝试次数
 const WS_RECONNECT_DELAY = 3000 // WebSocket重连延迟（3秒）
 const WS_RECONNECT_DELAY_MAX = 30000 // WebSocket重连最大延迟（30秒）
 const WS_RECONNECT_BACKOFF = 1.5 // WebSocket重连退避倍数
@@ -103,6 +103,7 @@ interface GlobalWSStorage {
   backendDevMode: boolean
   backendCheckTimer?: number
   backendRestartAttempts: number
+  backendRestartFailureShown: boolean
   isRestartingBackend: boolean
   lastBackendCheck: number
   lastConnectAttempt: number
@@ -114,8 +115,7 @@ interface GlobalWSStorage {
   wsReconnectTimer?: number
   isAutoReconnecting: boolean
   lastDisconnectTime: number
-  reconnectFailureModalShown: boolean
-  autoRestartTimer?: number // 添加自动重启定时器
+  lastDisconnectWasHeartbeatTimeout: boolean
   // 全局订阅ID，避免重复订阅
   globalTaskManagerSubscriptionId?: string
   globalMainSubscriptionId?: string
@@ -143,6 +143,7 @@ const initGlobalStorage = (): GlobalWSStorage => ({
   backendDevMode: FRONTEND_DEV_MODE,
   backendCheckTimer: undefined,
   backendRestartAttempts: 0,
+  backendRestartFailureShown: false,
   isRestartingBackend: false,
   lastBackendCheck: 0,
   lastConnectAttempt: 0,
@@ -154,8 +155,7 @@ const initGlobalStorage = (): GlobalWSStorage => ({
   wsReconnectTimer: undefined,
   isAutoReconnecting: false,
   lastDisconnectTime: 0,
-  reconnectFailureModalShown: false,
-  autoRestartTimer: undefined, // 初始化自动重启定时器
+  lastDisconnectWasHeartbeatTimeout: false,
   // 初始化全局订阅ID
   globalTaskManagerSubscriptionId: undefined,
   globalMainSubscriptionId: undefined,
@@ -302,7 +302,6 @@ const restartBackend = async (): Promise<boolean> => {
       const result = await (window.electronAPI as any).startBackend()
       if (result?.success) {
         setBackendStatus('running')
-        global.backendRestartAttempts = 0
 
         // 重启成功后自动重连WebSocket
         setTimeout(async () => {
@@ -341,20 +340,105 @@ const restartBackend = async (): Promise<boolean> => {
   }
 }
 
+const isTrackedBackendRunning = async (): Promise<boolean | null> => {
+  try {
+    const status = await (window.electronAPI as any)?.backendStatus?.()
+    if (typeof status?.isRunning === 'boolean') {
+      return status.isRunning
+    }
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error)
+    logger.warn(`查询后端进程状态失败: ${errorMsg}`)
+  }
+  return null
+}
+
+const scheduleNextReconnectCycle = (delay: number) => {
+  const global = getGlobalStorage()
+  global.wsReconnectTimer = window.setTimeout(() => {
+    startAutoReconnect()
+  }, delay)
+}
+
+const showBackendRestartFailureModal = () => {
+  const global = getGlobalStorage()
+  if (global.backendRestartFailureShown) return
+
+  global.backendRestartFailureShown = true
+  global.isAutoReconnecting = false
+  setBackendStatus('error')
+
+  if (global.wsReconnectTimer) {
+    clearTimeout(global.wsReconnectTimer)
+    global.wsReconnectTimer = undefined
+  }
+
+  Modal.error({
+    title: '后端服务恢复失败',
+    content: '后端服务多次重启后仍无法建立连接，请重启整个应用后再试。',
+    okText: '重启应用',
+    onOk: () => {
+      const { showClosingOverlay } = useAppClosing()
+      showClosingOverlay()
+
+      if ((window.electronAPI as any)?.appRestart) {
+        ;(window.electronAPI as any).appRestart()
+      } else if ((window.electronAPI as any)?.windowClose) {
+        ;(window.electronAPI as any).windowClose()
+      } else {
+        window.location.reload()
+      }
+    },
+  })
+}
+
+const handleReconnectCycleFailure = async () => {
+  const global = getGlobalStorage()
+  global.isAutoReconnecting = false
+  global.wsReconnectAttempts = 0
+
+  const backendRunning = await isTrackedBackendRunning()
+  if (
+    backendRunning === false ||
+    (backendRunning === true && global.lastDisconnectWasHeartbeatTimeout)
+  ) {
+    logger.warn(
+      backendRunning
+        ? '心跳超时后重连失败，尝试重启无响应的后端服务'
+        : '后端进程已停止，尝试重启后端服务'
+    )
+    if (global.backendRestartAttempts >= MAX_BACKEND_RESTART_ATTEMPTS) {
+      showBackendRestartFailureModal()
+      return
+    }
+
+    const restarted = await restartBackend()
+    if (restarted) {
+      return
+    }
+    if (global.backendRestartAttempts >= MAX_BACKEND_RESTART_ATTEMPTS) {
+      showBackendRestartFailureModal()
+      return
+    }
+  }
+
+  scheduleNextReconnectCycle(global.backendDevMode ? DEV_MODE_RETRY_DELAY : WS_RECONNECT_DELAY_MAX)
+}
+
 // WebSocket自动重连功能
 const startAutoReconnect = () => {
   logger.info('startAutoReconnect函数被调用')
   const global = getGlobalStorage()
 
-  logger.info(
-    `重连状态检查: isAutoReconnecting=${global.isAutoReconnecting}, reconnectFailureModalShown=${global.reconnectFailureModalShown}`
-  )
+  logger.info(`重连状态检查: isAutoReconnecting=${global.isAutoReconnecting}`)
 
-  // 如果已经在重连中或者已经显示过失败弹窗，则不再重连
-  if (global.isAutoReconnecting || global.reconnectFailureModalShown) {
-    logger.warn(
-      `跳过重连: 已在重连中=${global.isAutoReconnecting}, 已显示弹窗=${global.reconnectFailureModalShown}`
-    )
+  if (global.backendRestartFailureShown) {
+    logger.warn('后端恢复失败弹窗已显示，停止自动重连')
+    return
+  }
+
+  if (global.isAutoReconnecting) {
+    logger.warn(`跳过重连: 已在重连中=${global.isAutoReconnecting}`)
     return
   }
 
@@ -375,23 +459,13 @@ const startAutoReconnect = () => {
   global.lastDisconnectTime = Date.now()
 
   logger.info(
-    `开始WebSocket自动重连，当前重试次数: ${global.wsReconnectAttempts}，最大重试次数: ${MAX_WS_RECONNECT_ATTEMPTS}`
+    `开始WebSocket自动重连，当前重试次数: ${global.wsReconnectAttempts}，每轮重试次数: ${WS_RECONNECT_CYCLE_ATTEMPTS}`
   )
 
   const attemptReconnect = () => {
-    if (global.wsReconnectAttempts >= MAX_WS_RECONNECT_ATTEMPTS) {
-      logger.debug(`达到最大重连次数 ${MAX_WS_RECONNECT_ATTEMPTS}，显示失败弹窗`)
-      global.isAutoReconnecting = false
-      if (global.backendDevMode) {
-        logger.warn('后端开发模式下跳过 WebSocket 异常弹窗，稍后继续协商新的连接地址')
-        global.wsReconnectAttempts = 0
-        global.reconnectFailureModalShown = false
-        global.wsReconnectTimer = window.setTimeout(() => {
-          startAutoReconnect()
-        }, DEV_MODE_RETRY_DELAY)
-        return
-      }
-      showReconnectFailureModal()
+    if (global.wsReconnectAttempts >= WS_RECONNECT_CYCLE_ATTEMPTS) {
+      logger.warn(`本轮重连失败，${WS_RECONNECT_DELAY_MAX}ms 后继续尝试`)
+      void handleReconnectCycleFailure()
       return
     }
 
@@ -494,163 +568,6 @@ const stopAutoReconnect = () => {
   }
 }
 
-// 显示重连失败弹窗
-const showReconnectFailureModal = () => {
-  const global = getGlobalStorage()
-
-  // 防止重复显示弹窗
-  if (global.reconnectFailureModalShown) {
-    logger.debug('重连失败弹窗已显示过，跳过')
-    return
-  }
-
-  logger.debug(
-    `显示重连失败弹窗，重试次数已达到: ${global.wsReconnectAttempts}/${MAX_WS_RECONNECT_ATTEMPTS}`
-  )
-  global.reconnectFailureModalShown = true
-  global.isAutoReconnecting = false
-
-  // 清除之前的自动重启定时器（如果存在）
-  if (global.autoRestartTimer) {
-    clearTimeout(global.autoRestartTimer)
-    global.autoRestartTimer = undefined
-  }
-
-  // 设置10秒后自动重启后端服务
-  let autoRestartExecuted = false
-  global.autoRestartTimer = window.setTimeout(async () => {
-    if (!autoRestartExecuted) {
-      autoRestartExecuted = true
-      logger.debug('用户10秒内无响应，自动重启后端服务')
-
-      // 关闭可能存在的弹窗
-      Modal.destroyAll()
-
-      // 执行重启后端服务的逻辑
-      global.reconnectFailureModalShown = false
-      resetReconnectState()
-
-      try {
-        const success = await restartBackend()
-        if (success) {
-          logger.debug('自动重启后端成功，开始重新连接')
-          setConnectionPermission(true, '后端重启后重连')
-
-          setTimeout(async () => {
-            try {
-              const connected = await connectGlobalWebSocket('后端重启后重连')
-              if (connected) {
-                logger.debug('自动重启后端后WebSocket重连成功')
-                setTimeout(() => {
-                  setConnectionPermission(false, '正常运行中')
-                }, 1000)
-                startBackendMonitoring()
-              } else {
-                logger.warn('自动重启后端后WebSocket重连失败，启动自动重连')
-                startAutoReconnect()
-              }
-            } catch (e) {
-              const errorMsg = e instanceof Error ? e.message : String(e)
-              logger.warn(`自动重启后端后重连异常: ${errorMsg}`)
-              startAutoReconnect()
-            }
-          }, RESTART_DELAY)
-        } else {
-          logger.warn('自动重启后端失败，启动自动重连')
-          startAutoReconnect()
-        }
-      } catch (e) {
-        const errorMsg = e instanceof Error ? e.message : String(e)
-        logger.warn(`自动重启后端异常: ${errorMsg}`)
-        startAutoReconnect()
-      }
-    }
-  }, 10000) // 10秒
-
-  Modal.confirm({
-    title: 'WebSocket连接异常',
-    content:
-      'WebSocket连接已断开且多次重连失败，这可能是因为后端服务异常。请选择处理方式：（10秒后将自动重启后端服务）',
-    okText: '重启整个应用',
-    cancelText: '重启后端服务',
-    centered: true,
-    maskClosable: false,
-    onOk: () => {
-      // 清除自动重启定时器
-      if (global.autoRestartTimer) {
-        clearTimeout(global.autoRestartTimer)
-        global.autoRestartTimer = undefined
-      }
-      autoRestartExecuted = true
-
-      logger.debug('用户选择重启整个应用')
-      // 显示关闭遮罩
-      const { showClosingOverlay } = useAppClosing()
-      showClosingOverlay()
-
-      // 重启整个应用
-      if ((window.electronAPI as any)?.appRestart) {
-        ;(window.electronAPI as any).appRestart()
-      } else if ((window.electronAPI as any)?.windowClose) {
-        ;(window.electronAPI as any).windowClose()
-      } else {
-        window.location.reload()
-      }
-    },
-    onCancel: async () => {
-      // 清除自动重启定时器
-      if (global.autoRestartTimer) {
-        clearTimeout(global.autoRestartTimer)
-        global.autoRestartTimer = undefined
-      }
-      autoRestartExecuted = true
-
-      logger.debug('用户选择重启后端服务')
-      // 重置重连状态并重启后端服务
-      global.reconnectFailureModalShown = false
-      resetReconnectState()
-
-      try {
-        // 重启后端服务
-        const success = await restartBackend()
-        if (success) {
-          logger.debug('后端重启成功，开始重新连接')
-          // 设置连接权限
-          setConnectionPermission(true, '后端重启后重连')
-
-          // 等待后端完全启动后重连
-          setTimeout(async () => {
-            try {
-              const connected = await connectGlobalWebSocket('后端重启后重连')
-              if (connected) {
-                logger.debug('重启后端后WebSocket重连成功')
-                setTimeout(() => {
-                  setConnectionPermission(false, '正常运行中')
-                }, 1000)
-                startBackendMonitoring()
-              } else {
-                logger.warn('重启后端后WebSocket重连失败，启动自动重连')
-                startAutoReconnect()
-              }
-            } catch (e) {
-              const errorMsg = e instanceof Error ? e.message : String(e)
-              logger.warn(`重启后端后重连异常: ${errorMsg}`)
-              startAutoReconnect()
-            }
-          }, RESTART_DELAY)
-        } else {
-          logger.warn('后端重启失败，启动自动重连')
-          startAutoReconnect()
-        }
-      } catch (e) {
-        const errorMsg = e instanceof Error ? e.message : String(e)
-        logger.warn(`后端重启异常: ${errorMsg}`)
-        startAutoReconnect()
-      }
-    },
-  })
-}
-
 // 重置重连状态
 const resetReconnectState = () => {
   const global = getGlobalStorage()
@@ -658,14 +575,7 @@ const resetReconnectState = () => {
     `重置重连状态，之前的重试次数: ${global.wsReconnectAttempts}，自动重连中: ${global.isAutoReconnecting}`
   )
   global.wsReconnectAttempts = 0
-  global.reconnectFailureModalShown = false
-
-  // 清除自动重启定时器
-  if (global.autoRestartTimer) {
-    clearTimeout(global.autoRestartTimer)
-    global.autoRestartTimer = undefined
-    logger.debug('已清除自动重启定时器')
-  }
+  global.lastDisconnectWasHeartbeatTimeout = false
 
   stopAutoReconnect()
   logger.debug(`重连状态已重置，当前自动重连状态: ${global.isAutoReconnecting}`)
@@ -684,7 +594,8 @@ const resetWebSocketState = () => {
   // 重置重连状态
   global.wsReconnectAttempts = 0
   global.isAutoReconnecting = false
-  global.reconnectFailureModalShown = false
+  global.backendRestartFailureShown = false
+  global.lastDisconnectWasHeartbeatTimeout = false
 
   // 清除所有定时器
   if (global.wsReconnectTimer) {
@@ -692,89 +603,10 @@ const resetWebSocketState = () => {
     global.wsReconnectTimer = undefined
   }
 
-  if (global.autoRestartTimer) {
-    clearTimeout(global.autoRestartTimer)
-    global.autoRestartTimer = undefined
-  }
-
   // 重置连接权限
   setConnectionPermission(true, '状态重置')
 
   logger.debug('WebSocket状态完全重置完成')
-}
-
-const handleBackendFailure = async () => {
-  const global = getGlobalStorage()
-  logger.debug(`后端故障处理开始，当前重启尝试次数: ${global.backendRestartAttempts}`)
-
-  if (global.backendRestartAttempts >= MAX_RESTART_ATTEMPTS) {
-    logger.warn('后端多次重启失败，显示最终错误弹窗')
-    Modal.error({
-      title: '后端服务异常',
-      content: '后端服务多次重启失败，请重启整个应用程序。',
-      okCancel: true,
-      okText: '重启应用',
-      cancelText: '取消',
-      onOk: () => {
-        // 显示关闭遮罩
-        const { showClosingOverlay } = useAppClosing()
-        showClosingOverlay()
-
-        if ((window.electronAPI as any)?.appRestart) {
-          ;(window.electronAPI as any).appRestart()
-        } else if ((window.electronAPI as any)?.windowClose) {
-          ;(window.electronAPI as any).windowClose()
-        } else {
-          window.location.reload()
-        }
-      },
-      onCancel: () => {
-        return
-      },
-    })
-    return
-  }
-
-  setTimeout(async () => {
-    logger.debug('尝试重启后端服务...')
-    const success = await restartBackend()
-    if (success) {
-      logger.debug('后端重启成功，准备重新连接')
-      // 统一在一个地方管理连接权限
-      setConnectionPermission(true, '后端重启后重连')
-
-      // 等待后端完全启动
-      setTimeout(async () => {
-        try {
-          logger.debug('尝试重新建立WebSocket连接')
-          const connected = await connectGlobalWebSocket('后端重启后重连')
-          if (connected) {
-            logger.debug('后端重启后WebSocket重连成功')
-            // 连接成功后再禁用权限
-            setTimeout(() => {
-              setConnectionPermission(false, '正常运行中')
-              resetReconnectState() // 重置重连状态
-            }, 1000)
-            startBackendMonitoring() // 启动后端监控
-          } else {
-            logger.warn('后端重启后WebSocket重连失败')
-            setConnectionPermission(false, '连接失败')
-            // 如果重连失败，可以尝试启动自动重连
-            startAutoReconnect()
-          }
-        } catch (e) {
-          const errorMsg = e instanceof Error ? e.message : String(e)
-          logger.warn(`重启后重连异常: ${errorMsg}`)
-          setConnectionPermission(false, '连接失败')
-          startAutoReconnect()
-        }
-      }, RESTART_DELAY)
-    } else {
-      logger.warn('后端重启失败，继续尝试')
-      // 重启失败，继续尝试
-      setTimeout(handleBackendFailure, RESTART_DELAY)
-    }
-  }, RESTART_DELAY)
 }
 
 const startBackendMonitoring = () => {
@@ -1116,6 +948,9 @@ const createGlobalWebSocket = (): WebSocket => {
     global.reconnectAttempts = 0
     setGlobalStatus('已连接')
     setBackendStatus('running') // WebSocket连接成功时设置后端为运行状态
+    global.backendRestartAttempts = 0
+    global.backendRestartFailureShown = false
+    global.lastDisconnectWasHeartbeatTimeout = false
     startGlobalHeartbeat(ws)
 
     // 立即重置WebSocket重连状态
@@ -1183,12 +1018,8 @@ const createGlobalWebSocket = (): WebSocket => {
       logger.info(`WebSocket连接关闭事件触发: code=${event.code}, reason="${event.reason}"`)
     }
     setGlobalStatus('已断开')
-    // WebSocket断开时设置后端状态
-    if (isHeartbeatTimeout) {
-      setBackendStatus('error')
-    } else {
-      setBackendStatus('stopped')
-    }
+    setBackendStatus('stopped')
+    global.lastDisconnectWasHeartbeatTimeout = isHeartbeatTimeout
     stopGlobalHeartbeat()
     global.isConnecting = false
 
@@ -1200,13 +1031,7 @@ const createGlobalWebSocket = (): WebSocket => {
     global.lastConnectAttempt = 0
 
     // 根据关闭原因决定处理方式
-    if (isHeartbeatTimeout) {
-      // 心跳超时通常意味着后端有问题，直接处理后端故障
-      handleBackendFailure().catch(e => {
-        const errorMsg = e instanceof Error ? e.message : String(e)
-        logger.error(`后端故障处理失败: ${errorMsg}`)
-      })
-    } else if (event.code === 1000 && event.reason === '正常关闭') {
+    if (event.code === 1000 && event.reason === '正常关闭') {
       // 明确的正常关闭，不重连
       logger.debug('WebSocket正常关闭，不启动重连')
     } else {
@@ -1228,8 +1053,7 @@ const createGlobalWebSocket = (): WebSocket => {
         // 直接调用attemptReconnect来继续重连流程
         // 但是我们需要访问attemptReconnect函数，这里先用一个简单的方法
         setTimeout(() => {
-          if (global.wsReconnectAttempts < 5) {
-            // MAX_WS_RECONNECT_ATTEMPTS
+          if (global.wsReconnectAttempts < WS_RECONNECT_CYCLE_ATTEMPTS) {
             logger.info('延迟触发下一次重连尝试')
             // 这里我们需要一个方法来继续重连，暂时重置状态让新的重连开始
             global.isAutoReconnecting = false
@@ -1574,12 +1398,12 @@ export function useWebSocket() {
     wsReconnectAttempts: global.wsReconnectAttempts,
     isAutoReconnecting: global.isAutoReconnecting,
     lastDisconnectTime: global.lastDisconnectTime,
-    reconnectFailureModalShown: global.reconnectFailureModalShown,
   })
 
   const restartBackendManually = async () => {
     const g = getGlobalStorage()
     g.backendRestartAttempts = 0
+    g.backendRestartFailureShown = false
     return await restartBackend()
   }
 
@@ -1601,7 +1425,7 @@ export function useWebSocket() {
     // 重置所有可能阻止重连的状态
     global.isConnecting = false
     global.lastConnectAttempt = 0
-    global.reconnectFailureModalShown = false
+    global.backendRestartFailureShown = false
 
     // 停止现有的重连尝试
     stopAutoReconnect()


### PR DESCRIPTION
## Summary
- Keep the backend alive when the main WebSocket drops so sleep/resume can reconnect instead of forcing MAS restart.
- Restore recovery for real backend exits by checking the tracked backend process before restarting.
- Prevent repeated startup queue runs on reconnect and clean stale backend processes before a fresh start.

## Checks
- python -m py_compile app\api\core.py app\core\task_manager.py
- yarn lint (passes with existing v-html warnings)
- yarn build:main
- git diff --check

Note: user-visible behavior changed; update res/version.json before release.

## Summary by Sourcery

改进 WebSocket 重连和后端生命周期处理，在出现短暂断连时保持后端存活，并仅在真正需要时安全地重启。

新功能：
- 添加启动前检查，在启动新实例之前复用或优雅关闭任何已有但未被跟踪的后端。
- 保护后端启动任务队列，确保它只在 WebSocket 连接稳定建立后运行一次。
- 确保 virtualenv 的 Python 路径配置文件同步到 venv 中，使环境可以可靠地执行。

缺陷修复：
- 将主 WebSocket 断开视为可恢复事件，而不是强制后端自我终止，从而支持睡眠/唤醒后的恢复。
- 重置并简化 WebSocket 重连流程，避免无限重连循环和多余的后端重启。
- 修复 Windows 进程发现逻辑，不再错误地将主应用程序可执行文件识别为受管后端进程。

改进与优化：
- 用后台自动重连流程替代基于弹窗的 WebSocket 错误处理，当受管后端宕机或无响应时，该流程可以触发有限次数的后端重启。
- 标准化 WebSocket 关闭时的后端状态为“stopped”，并跟踪心跳超时以辅助重启决策，从而对齐开发环境和生产环境行为。
- 添加启动前的 HTTP 检查，在启动新生产后端之前检测并干净关闭任何现有的生产后端，以避免端口冲突。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve WebSocket reconnection and backend lifecycle handling to keep the backend alive across transient disconnects while safely restarting only when truly needed.

New Features:
- Add pre-start checks to reuse or gracefully shut down any existing untracked backend before starting a new instance.
- Guard the backend startup task queue so it runs only once after a stable WebSocket connection is established.
- Ensure virtualenv Python path configuration files are synchronized into the venv to make the environment reliably executable.

Bug Fixes:
- Treat main WebSocket disconnects as recoverable events instead of forcing backend self-termination, enabling sleep/resume recovery.
- Reset and simplify WebSocket reconnection cycles to avoid infinite reconnect loops and redundant backend restarts.
- Fix Windows process discovery to no longer misidentify the main application executable as a managed backend process.

Enhancements:
- Replace modal-driven WebSocket error handling with a background auto-reconnect cycle that can trigger limited backend restarts when the tracked backend is down or unresponsive.
- Standardize backend status to "stopped" on WebSocket close and track heartbeat timeouts to inform restart decisions, aligning dev and production behavior.
- Add pre-start HTTP checks to detect and cleanly close any existing production backend before launching a new one, avoiding port conflicts.

</details>

新功能：
- 在 WebSocket 重连周期中尝试自动重启后端之前新增后端状态检查。
- 在启动前新增检查逻辑，在启动新后端实例前关闭任何“可访问但未被跟踪”的现有后端实例。
- 通过跟踪后端启动任务队列的首次执行状态，确保该队列只运行一次。

缺陷修复：
- 将主 WebSocket 断线视为可恢复情况，保持后端存活而不是触发后端自我终止。
- 通过重置 WebSocket 重连周期并简化失败处理，避免重连循环和重复的启动流程。
- 修复进程发现逻辑，避免将主应用程序可执行文件误识别为受管的后端进程。

改进优化：
- 简化 WebSocket 失败时的用户体验，移除基于模态框的重连提示，改为依赖带退避机制的自动重连周期。
- 将 WebSocket 关闭时的后端状态统一标准化为“已停止”，并调整重连逻辑，使开发模式与生产环境的行为保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进 WebSocket 重连和后端生命周期处理，在出现短暂断连时保持后端存活，并仅在真正需要时安全地重启。

新功能：
- 添加启动前检查，在启动新实例之前复用或优雅关闭任何已有但未被跟踪的后端。
- 保护后端启动任务队列，确保它只在 WebSocket 连接稳定建立后运行一次。
- 确保 virtualenv 的 Python 路径配置文件同步到 venv 中，使环境可以可靠地执行。

缺陷修复：
- 将主 WebSocket 断开视为可恢复事件，而不是强制后端自我终止，从而支持睡眠/唤醒后的恢复。
- 重置并简化 WebSocket 重连流程，避免无限重连循环和多余的后端重启。
- 修复 Windows 进程发现逻辑，不再错误地将主应用程序可执行文件识别为受管后端进程。

改进与优化：
- 用后台自动重连流程替代基于弹窗的 WebSocket 错误处理，当受管后端宕机或无响应时，该流程可以触发有限次数的后端重启。
- 标准化 WebSocket 关闭时的后端状态为“stopped”，并跟踪心跳超时以辅助重启决策，从而对齐开发环境和生产环境行为。
- 添加启动前的 HTTP 检查，在启动新生产后端之前检测并干净关闭任何现有的生产后端，以避免端口冲突。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve WebSocket reconnection and backend lifecycle handling to keep the backend alive across transient disconnects while safely restarting only when truly needed.

New Features:
- Add pre-start checks to reuse or gracefully shut down any existing untracked backend before starting a new instance.
- Guard the backend startup task queue so it runs only once after a stable WebSocket connection is established.
- Ensure virtualenv Python path configuration files are synchronized into the venv to make the environment reliably executable.

Bug Fixes:
- Treat main WebSocket disconnects as recoverable events instead of forcing backend self-termination, enabling sleep/resume recovery.
- Reset and simplify WebSocket reconnection cycles to avoid infinite reconnect loops and redundant backend restarts.
- Fix Windows process discovery to no longer misidentify the main application executable as a managed backend process.

Enhancements:
- Replace modal-driven WebSocket error handling with a background auto-reconnect cycle that can trigger limited backend restarts when the tracked backend is down or unresponsive.
- Standardize backend status to "stopped" on WebSocket close and track heartbeat timeouts to inform restart decisions, aligning dev and production behavior.
- Add pre-start HTTP checks to detect and cleanly close any existing production backend before launching a new one, avoiding port conflicts.

</details>

</details>