### PR TITLE
[codex] Support Vite browser dev mode

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,3 +1,4 @@
+import '@/utils/browserDevElectronAPI'
 import { createApp } from 'vue'
 import dayjs from 'dayjs'
 import 'dayjs/locale/zh-cn'
@@ -11,6 +12,11 @@ import WebSocketMessageListener from '@/components/WebSocketMessageListener.vue'
 import { installPluginAPI } from '@/plugin/pluginAPI'
 
 const logger = window.electronAPI.getLogger('前端主入口')
+if (
+  (window as Window & { __AUTO_MAS_BROWSER_DEV_MODE__?: boolean }).__AUTO_MAS_BROWSER_DEV_MODE__
+) {
+  OpenAPI.BASE = 'http://localhost:36163'
+}
 
 dayjs.locale('zh-cn')
 installPluginAPI()

--- a/frontend/src/utils/browserDevElectronAPI.ts
+++ b/frontend/src/utils/browserDevElectronAPI.ts
@@ -8,11 +8,6 @@ const BACKEND_WS_ENDPOINT = 'ws://localhost:36163'
 const CONFIG_KEY = 'app-config'
 const INITIALIZED_VERSION_KEY = 'app-initialized-version'
 
-const unsupportedLocalOperation = async () => ({
-  success: false,
-  error: 'Vite browser dev mode cannot run Electron local operations.',
-})
-
 const readJsonStorage = <T>(key: string): T | null => {
   const raw = localStorage.getItem(key)
   if (!raw) return null
@@ -39,44 +34,35 @@ const getLogger = (moduleName: string): Logger => {
   }
 }
 
-const browserDevElectronAPI = new Proxy(
-  {
-    getLogger,
-    getApiEndpoint: async (key: string) =>
-      key === 'websocket' ? BACKEND_WS_ENDPOINT : BACKEND_HTTP_ENDPOINT,
-    getApiEndpoints: async () => ({ local: BACKEND_HTTP_ENDPOINT, websocket: BACKEND_WS_ENDPOINT }),
-    openUrl: async (url: string) => {
-      window.open(url, '_blank', 'noopener,noreferrer')
-      return { success: true }
-    },
-    windowFocus: async () => window.focus(),
-    selectFolder: async () => null,
-    selectFile: async () => [],
-    saveConfig: async (config: unknown) => {
-      localStorage.setItem(CONFIG_KEY, JSON.stringify(config))
-    },
-    loadConfig: async () => readJsonStorage(CONFIG_KEY),
-    resetConfig: async () => {
-      localStorage.removeItem(CONFIG_KEY)
-    },
-    getInitializedVersion: async () => localStorage.getItem(INITIALIZED_VERSION_KEY),
-    setInitializedVersion: async (version: string) => {
-      localStorage.setItem(INITIALIZED_VERSION_KEY, version)
-      return true
-    },
-    fileExists: async () => false,
-    readFile: async () => '',
-    getAppPath: async () => '',
-    backendStatus: async () => ({ isRunning: true, wsConnected: false }),
+const browserDevElectronAPI = {
+  getLogger,
+  getApiEndpoint: async (key: string) =>
+    key === 'websocket' ? BACKEND_WS_ENDPOINT : BACKEND_HTTP_ENDPOINT,
+  getApiEndpoints: async () => ({ local: BACKEND_HTTP_ENDPOINT, websocket: BACKEND_WS_ENDPOINT }),
+  openUrl: async (url: string) => {
+    window.open(url, '_blank', 'noopener,noreferrer')
+    return { success: true }
   },
-  {
-    get(target, prop: string | symbol) {
-      if (prop === 'then') return undefined
-      if (prop in target) return target[prop as keyof typeof target]
-      return unsupportedLocalOperation
-    },
-  }
-) as unknown as ElectronAPI
+  windowFocus: async () => window.focus(),
+  selectFolder: async () => null,
+  selectFile: async () => [],
+  saveConfig: async (config: unknown) => {
+    localStorage.setItem(CONFIG_KEY, JSON.stringify(config))
+  },
+  loadConfig: async () => readJsonStorage(CONFIG_KEY),
+  resetConfig: async () => {
+    localStorage.removeItem(CONFIG_KEY)
+  },
+  getInitializedVersion: async () => localStorage.getItem(INITIALIZED_VERSION_KEY),
+  setInitializedVersion: async (version: string) => {
+    localStorage.setItem(INITIALIZED_VERSION_KEY, version)
+    return true
+  },
+  fileExists: async () => false,
+  readFile: async () => '',
+  getAppPath: async () => '',
+  backendStatus: async () => ({ isRunning: true, wsConnected: false }),
+} as unknown as ElectronAPI
 
 if (import.meta.env.DEV && !window.electronAPI) {
   ;(window as BrowserDevWindow).__AUTO_MAS_BROWSER_DEV_MODE__ = true

--- a/frontend/src/utils/browserDevElectronAPI.ts
+++ b/frontend/src/utils/browserDevElectronAPI.ts
@@ -1,0 +1,84 @@
+import type { ElectronAPI } from '@/types/electron'
+
+type BrowserDevWindow = Window & { __AUTO_MAS_BROWSER_DEV_MODE__?: boolean }
+type Logger = ReturnType<ElectronAPI['getLogger']>
+
+const BACKEND_HTTP_ENDPOINT = 'http://localhost:36163'
+const BACKEND_WS_ENDPOINT = 'ws://localhost:36163'
+const CONFIG_KEY = 'app-config'
+const INITIALIZED_VERSION_KEY = 'app-initialized-version'
+
+const unsupportedLocalOperation = async () => ({
+  success: false,
+  error: 'Vite browser dev mode cannot run Electron local operations.',
+})
+
+const readJsonStorage = <T>(key: string): T | null => {
+  const raw = localStorage.getItem(key)
+  if (!raw) return null
+
+  try {
+    return JSON.parse(raw) as T
+  } catch {
+    return null
+  }
+}
+
+const getLogger = (moduleName: string): Logger => {
+  const write =
+    (level: 'debug' | 'info' | 'warn' | 'error') =>
+    async (...args: unknown[]) => {
+      console[level](`[${moduleName}]`, ...args)
+    }
+
+  return {
+    debug: write('debug'),
+    info: write('info'),
+    warn: write('warn'),
+    error: write('error'),
+  }
+}
+
+const browserDevElectronAPI = new Proxy(
+  {
+    getLogger,
+    getApiEndpoint: async (key: string) =>
+      key === 'websocket' ? BACKEND_WS_ENDPOINT : BACKEND_HTTP_ENDPOINT,
+    getApiEndpoints: async () => ({ local: BACKEND_HTTP_ENDPOINT, websocket: BACKEND_WS_ENDPOINT }),
+    openUrl: async (url: string) => {
+      window.open(url, '_blank', 'noopener,noreferrer')
+      return { success: true }
+    },
+    windowFocus: async () => window.focus(),
+    selectFolder: async () => null,
+    selectFile: async () => [],
+    saveConfig: async (config: unknown) => {
+      localStorage.setItem(CONFIG_KEY, JSON.stringify(config))
+    },
+    loadConfig: async () => readJsonStorage(CONFIG_KEY),
+    resetConfig: async () => {
+      localStorage.removeItem(CONFIG_KEY)
+    },
+    getInitializedVersion: async () => localStorage.getItem(INITIALIZED_VERSION_KEY),
+    setInitializedVersion: async (version: string) => {
+      localStorage.setItem(INITIALIZED_VERSION_KEY, version)
+      return true
+    },
+    fileExists: async () => false,
+    readFile: async () => '',
+    getAppPath: async () => '',
+    backendStatus: async () => ({ isRunning: true, wsConnected: false }),
+  },
+  {
+    get(target, prop: string | symbol) {
+      if (prop === 'then') return undefined
+      if (prop in target) return target[prop as keyof typeof target]
+      return unsupportedLocalOperation
+    },
+  }
+) as unknown as ElectronAPI
+
+if (import.meta.env.DEV && !window.electronAPI) {
+  ;(window as BrowserDevWindow).__AUTO_MAS_BROWSER_DEV_MODE__ = true
+  window.electronAPI = browserDevElectronAPI
+}


### PR DESCRIPTION
﻿- Add a Vite-dev-only browser `electronAPI` shim so `yarn web` can run the renderer directly in a normal browser without Electron preload.
- Point the browser dev shim at the existing backend endpoints on `localhost:36163` and keep Electron dev/desktop paths untouched because the shim only installs when `import.meta.env.DEV && !window.electronAPI`.
- Removed the previous FastAPI `frontend/dist` serving approach from this PR; production browser hosting is out of scope.
- Checks: `yarn lint` (existing `v-html` warnings only); `.\node_modules\.bin\vite.cmd build`; `python -m py_compile main.py`; Vite dev endpoint check on `http://127.0.0.1:5173` with `@vite/client` and `/src/main.ts` present.

## Summary by Sourcery

引入一个仅用于浏览器的 ElectronAPI shim，以支持在开发过程中通过 Vite 在标准浏览器中运行 Vue 渲染器，将其 API 端点接线到现有后端，同时保持基于 Electron 的流程不变。

新功能：
- 添加一个 Vite 浏览器开发模式的 shim，在渲染器在普通浏览器中运行时，提供基于浏览器的 ElectronAPI 实现。

改进：
- 在浏览器开发模式激活时，将前端 API 调用路由到运行在 `localhost:36163` 的现有后端，而不影响 Electron 桌面/开发模式的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a browser-only ElectronAPI shim to support running the Vue renderer via Vite in a standard browser during development, wiring its API endpoints to the existing backend while leaving Electron-based flows unchanged.

New Features:
- Add a Vite browser dev mode shim that provides a browser-based implementation of the ElectronAPI when running the renderer in a normal browser.

Enhancements:
- Route frontend API calls to the existing backend on localhost:36163 when browser dev mode is active, without affecting Electron desktop/dev behavior.

</details>