### PR TITLE
[codex] restore Okww plugin edit page visual parity

### DIFF
--- a/frontend/src/utils/scriptRegistry.ts
+++ b/frontend/src/utils/scriptRegistry.ts
@@ -124,6 +124,9 @@ const BUILTIN_EDITOR_SEGMENTS: Record<string, string> = {
 }
 
 export const getScriptEditPath = (script: Pick<Script, 'id' | 'type' | 'editorKind'>) => {
+  if (script.type === 'Okww') {
+    return `/scripts/${script.id}/edit/okww`
+  }
   const segment = BUILTIN_EDITOR_SEGMENTS[script.editorKind ?? '']
   if (segment) {
     return `/scripts/${script.id}/edit/${segment}`
@@ -134,7 +137,10 @@ export const getScriptEditPath = (script: Pick<Script, 'id' | 'type' | 'editorKi
   return `/scripts/${script.id}/edit/schema`
 }
 
-export const getUserCreatePath = (script: Pick<Script, 'id' | 'editorKind'>) => {
+export const getUserCreatePath = (script: Pick<Script, 'id' | 'type' | 'editorKind'>) => {
+  if (script.type === 'Okww') {
+    return `/scripts/${script.id}/users/add/okww`
+  }
   const segment = BUILTIN_EDITOR_SEGMENTS[script.editorKind ?? '']
   if (segment) {
     return `/scripts/${script.id}/users/add/${segment}`
@@ -146,9 +152,12 @@ export const getUserCreatePath = (script: Pick<Script, 'id' | 'editorKind'>) => 
 }
 
 export const getUserEditPath = (
-  script: Pick<Script, 'id' | 'editorKind'>,
+  script: Pick<Script, 'id' | 'type' | 'editorKind'>,
   user: Pick<User, 'id'>
 ) => {
+  if (script.type === 'Okww') {
+    return `/scripts/${script.id}/users/${user.id}/edit/okww`
+  }
   const segment = BUILTIN_EDITOR_SEGMENTS[script.editorKind ?? '']
   if (segment) {
     return `/scripts/${script.id}/users/${user.id}/edit/${segment}`

--- a/frontend/src/views/EditView/Script/OkwwScriptEdit.vue
+++ b/frontend/src/views/EditView/Script/OkwwScriptEdit.vue
@@ -272,12 +272,12 @@ import {
   FolderOpenOutlined,
   QuestionCircleOutlined,
 } from '@ant-design/icons-vue'
-import { useScriptApi } from '@/composables/useScriptApi'
+import { useScriptRegistryApi } from '@/composables/useScriptRegistryApi'
 
 const logger = window.electronAPI.getLogger('ok-ww脚本编辑')
 const route = useRoute()
 const router = useRouter()
-const { getScript, updateScript } = useScriptApi()
+const api = useScriptRegistryApi()
 
 const scriptId = route.params.id as string
 const pageLoading = ref(true)
@@ -359,20 +359,32 @@ const showPathRejectModal = (title: string, content: string) => {
 
 const handleCancel = () => router.push('/scripts')
 
-const handleChange = async (category: string, key: string, value: unknown) => {
-  if (isInitializing.value || isSaving.value) return
+const saveScriptPatch = async (
+  patch: Record<string, Record<string, unknown>>,
+  successMessage?: string
+) => {
   isSaving.value = true
   try {
-    const updateData = { [category]: { [key]: value } } as Record<string, Record<string, unknown>>
-    const success = await updateScript(scriptId, updateData)
-    if (success) {
-      logger.info(`配置已保存: ${category}.${key}`)
+    await api.updateScript(scriptId, patch)
+    if (successMessage) {
+      message.success(successMessage)
     }
+    return true
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e)
     logger.error(msg)
+    message.error(msg)
+    return false
   } finally {
     isSaving.value = false
+  }
+}
+
+const handleChange = async (category: string, key: string, value: unknown) => {
+  if (isInitializing.value || isSaving.value) return
+  const updateData = { [category]: { [key]: value } } as Record<string, Record<string, unknown>>
+  if (await saveScriptPatch(updateData)) {
+    logger.info(`Okww config saved: ${category}.${key}`)
   }
 }
 
@@ -384,48 +396,44 @@ const applyRootPathDefaults = async (rootPath: string) => {
   const norm = rootPath.replace(/\\/g, '/').replace(/\/+$/g, '')
   okwwConfig.Info.RootPath = norm
 
-  isSaving.value = true
-  try {
-    const success = await updateScript(scriptId, {
+  await saveScriptPatch(
+    {
       Info: { RootPath: norm },
-    })
-    if (success) {
-      message.success('ok-ww 根目录已保存')
-    }
-  } finally {
-    isSaving.value = false
-  }
+    },
+    'ok-ww 根目录已保存'
+  )
 }
-
 const loadScript = async () => {
   pageLoading.value = true
   isInitializing.value = true
   try {
-    const detail = await getScript(scriptId)
-    if (!detail) {
+    const records = await api.getScripts(scriptId)
+    const record = records[0]
+    if (!record) {
       message.error('脚本不存在或加载失败')
       handleCancel()
       return
     }
-    if (detail.type !== 'Okww') {
+    if (record.type !== 'Okww') {
       message.error('脚本类型不是 ok-ww')
       handleCancel()
       return
     }
-    formData.name = detail.name
-    const config = detail.config as Partial<OkwwScriptConfigForm>
+    formData.name = record.name
+    const config = record.config as Partial<OkwwScriptConfigForm>
     Object.assign(okwwConfig.Info, config.Info || {})
     Object.assign(okwwConfig.Script, config.Script || {})
     Object.assign(okwwConfig.Game, config.Game || {})
     Object.assign(okwwConfig.Run, config.Run || {})
-  } catch {
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    logger.error(msg)
     message.error('加载脚本失败')
   } finally {
     isInitializing.value = false
     pageLoading.value = false
   }
 }
-
 const selectRootPath = async () => {
   const picked = await window.electronAPI.selectFolder()
   if (!picked) return
@@ -461,10 +469,14 @@ const selectGameRootPath = async () => {
       okwwConfig.Game.Path = candidateExe
       isSaving.value = true
       try {
-        await updateScript(scriptId, {
+        await api.updateScript(scriptId, {
           Game: { Path: okwwConfig.Game.Path },
         })
         message.success('已自动匹配游戏路径至 Client-Win64-Shipping.exe')
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e)
+        logger.error(msg)
+        message.error(msg)
       } finally {
         isSaving.value = false
       }

--- a/frontend/src/views/EditView/User/OkwwUserEdit.vue
+++ b/frontend/src/views/EditView/User/OkwwUserEdit.vue
@@ -243,6 +243,7 @@
           v-if="userId"
           :script-id="scriptId"
           :user-id="userId"
+          endpoint-prefix="/plugin/okww/configs"
           @saved="handleConfigSaved"
         />
       </a-card>
@@ -343,8 +344,7 @@ import { computed, nextTick, onMounted, reactive, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { message } from 'ant-design-vue'
 import { ArrowLeftOutlined, QuestionCircleOutlined } from '@ant-design/icons-vue'
-import { useUserApi } from '@/composables/useUserApi'
-import { useScriptApi } from '@/composables/useScriptApi'
+import { useScriptRegistryApi } from '@/composables/useScriptRegistryApi'
 import WebhookManager from '@/components/WebhookManager.vue'
 import OkwwConfigEditor from '@/views/OkwwUserEdit/OkwwConfigEditor.vue'
 import ExtraScriptSection from '@/components/ExtraScriptSection.vue'
@@ -352,8 +352,7 @@ import ExtraScriptSection from '@/components/ExtraScriptSection.vue'
 const logger = window.electronAPI.getLogger('ok-ww用户编辑')
 const route = useRoute()
 const router = useRouter()
-const { addUser, getUsers, updateUser } = useUserApi()
-const { getScript } = useScriptApi()
+const api = useScriptRegistryApi()
 
 const scriptId = route.params.scriptId as string
 const userId = ref((route.params.userId as string) || '')
@@ -465,11 +464,11 @@ const currentStartupArguments = computed(() => `-t ${formData.Task.TaskIndex || 
 const handleCancel = () => router.push('/scripts')
 
 const createUserImmediately = async () => {
-  const resp = await addUser(scriptId)
-  if (!resp?.userId) {
-    throw new Error(resp?.message || '创建用户失败')
+  const created = await api.addUser(scriptId)
+  if (!created?.id) {
+    throw new Error('创建用户失败')
   }
-  userId.value = resp.userId
+  userId.value = created.id
   isEdit.value = true
   await router.replace({
     name: 'OkwwUserEdit',
@@ -495,9 +494,11 @@ const saveField = async (key: string, value: unknown) => {
       formData.userName = String(value || '')
     }
 
-    await updateUser(scriptId, userId.value, patch)
+    await api.updateUser(scriptId, userId.value, patch)
   } catch (e) {
-    logger.error(e instanceof Error ? e.message : String(e))
+    const msg = e instanceof Error ? e.message : String(e)
+    logger.error(msg)
+    message.error(msg)
   } finally {
     isSaving.value = false
   }
@@ -505,7 +506,7 @@ const saveField = async (key: string, value: unknown) => {
 
 const saveTaskConfig = async () => {
   if (isInitializing.value || !userId.value) return
-  await updateUser(scriptId, userId.value, {
+  await api.updateUser(scriptId, userId.value, {
     Task: {
       TaskIndex: formData.Task.TaskIndex,
     },
@@ -517,14 +518,17 @@ const handleTaskIndexChange = async (value: number) => {
   try {
     await saveTaskConfig()
   } catch (e) {
-    logger.error(e instanceof Error ? e.message : String(e))
+    const msg = e instanceof Error ? e.message : String(e)
+    logger.error(msg)
+    message.error(msg)
   }
 }
 
 const loadScriptInfo = async () => {
-  const detail = await getScript(scriptId)
-  if (detail) {
-    scriptName.value = detail.name
+  const scripts = await api.getScripts(scriptId)
+  const script = scripts[0]
+  if (script) {
+    scriptName.value = script.name
   }
 }
 
@@ -534,14 +538,13 @@ const loadUser = async () => {
     if (!userId.value) {
       await createUserImmediately()
     }
-    const resp = await getUsers(scriptId, userId.value)
-    const userIndex = resp?.index?.find(i => i.uid === userId.value)
-    const data = resp?.data?.[userId.value]
-    if (!userIndex || !data) {
+    const users = await api.getUsers(scriptId, userId.value)
+    const user = users[0]
+    if (!user) {
       throw new Error('用户不存在或加载失败')
     }
 
-    const userData = data as Partial<OkwwUserFormData>
+    const userData = user.config as Partial<OkwwUserFormData>
 
     Object.assign(formData, {
       Info: { ...getDefaultUserData().Info, ...(userData.Info || {}) },
@@ -563,12 +566,13 @@ const loadUser = async () => {
       }
     }
     if (Object.keys(patch).length > 0) {
-      await updateUser(scriptId, userId.value, patch)
+      await api.updateUser(scriptId, userId.value, patch)
     }
     await nextTick()
     formData.userName = formData.Info.Name || ''
   } catch (e) {
-    logger.error(e instanceof Error ? e.message : String(e))
+    const msg = e instanceof Error ? e.message : String(e)
+    logger.error(msg)
     message.error('加载用户失败')
     handleCancel()
   } finally {
@@ -576,7 +580,6 @@ const loadUser = async () => {
     pageLoading.value = false
   }
 }
-
 const handleConfigSaved = () => {
   logger.info('OK-WW 配置已保存')
 }


### PR DESCRIPTION
- Route Okww script and user edit actions back to the existing Okww-specific edit pages instead of the generic plugin edit pages.
- Keep the new plugin/script registry APIs by adapting the old Okww pages to `useScriptRegistryApi` and plugin config endpoints.
- Root cause: pluginization migrated Okww storage and navigation to generic plugin editors, which changed the visual editing experience.
- Checks: `yarn format`; `yarn lint` (passes with existing `vue/no-v-html` warnings); `yarn vue-tsc --noEmit -p tsconfig.app.json` is blocked by existing unrelated type errors outside the touched files.