### PR TITLE
fix(M9A): 兼容新旧任务资源路径

### DIFF
--- a/app/task/M9A/task_loader.py
+++ b/app/task/M9A/task_loader.py
@@ -33,18 +33,38 @@ class M9ATaskLoader:
 
     def __init__(self, m9a_root_path: Path):
         self.root_path = m9a_root_path
-        self.tasks_dir = m9a_root_path / "resource/tasks"
+        self.tasks_dir = self._resolve_tasks_dir()
         self._task_cache: dict[str, dict] = {}
         self._raw_data_cache: dict[str, dict] = {}
         self._load_all_tasks()
 
+    def _resolve_tasks_dir(self) -> Path:
+        """兼容新版和旧版 M9A 的任务目录结构。"""
+        candidates = (
+            self.root_path / "tasks",
+            self.root_path / "resource/tasks",
+        )
+
+        for tasks_dir in candidates:
+            if tasks_dir.is_dir() and any(tasks_dir.glob("*.json")):
+                return tasks_dir
+
+        # 保留确定的路径用于错误日志；新版路径优先。
+        return next((path for path in candidates if path.is_dir()), candidates[0])
+
     def _load_all_tasks(self):
         """加载所有任务定义（包括 standalone 任务）"""
-        if not self.tasks_dir.exists():
-            logger.error(f"任务目录不存在：{self.tasks_dir}")
+        # M9A 热更新可能会在进程运行期间迁移任务目录，因此每次加载都重新探测。
+        self.tasks_dir = self._resolve_tasks_dir()
+        json_files = list(self.tasks_dir.glob("*.json"))
+        if not json_files:
+            logger.error(
+                "M9A 任务定义不存在，已检查："
+                f"{self.root_path / 'tasks'}、{self.root_path / 'resource/tasks'}"
+            )
             return
 
-        for json_file in self.tasks_dir.glob("*.json"):
+        for json_file in json_files:
             try:
                 data = json.loads(json_file.read_text(encoding="utf-8"))
 

--- a/tests/test_m9a_task_loader.py
+++ b/tests/test_m9a_task_loader.py
@@ -1,0 +1,65 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from app.task.M9A.task_loader import M9ATaskLoader
+
+
+class M9ATaskLoaderPathTest(unittest.TestCase):
+    @staticmethod
+    def _write_task(tasks_dir: Path, name: str) -> None:
+        tasks_dir.mkdir(parents=True, exist_ok=True)
+        (tasks_dir / "task.json").write_text(
+            json.dumps({"task": [{"name": name, "entry": name}]}),
+            encoding="utf-8",
+        )
+
+    def test_loads_new_tasks_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._write_task(root / "tasks", "new-task")
+
+            loader = M9ATaskLoader(root)
+
+            self.assertEqual(loader.tasks_dir, root / "tasks")
+            self.assertEqual(loader.get_all_task_names(), ["new-task"])
+
+    def test_loads_legacy_resource_tasks_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._write_task(root / "resource/tasks", "legacy-task")
+
+            loader = M9ATaskLoader(root)
+
+            self.assertEqual(loader.tasks_dir, root / "resource/tasks")
+            self.assertEqual(loader.get_all_task_names(), ["legacy-task"])
+
+    def test_prefers_new_tasks_directory_when_both_exist(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._write_task(root / "tasks", "new-task")
+            self._write_task(root / "resource/tasks", "legacy-task")
+
+            loader = M9ATaskLoader(root)
+
+            self.assertEqual(loader.tasks_dir, root / "tasks")
+            self.assertEqual(loader.get_all_task_names(), ["new-task"])
+
+    def test_reload_detects_directory_moved_by_hot_update(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            legacy_task = root / "resource/tasks/task.json"
+            self._write_task(legacy_task.parent, "legacy-task")
+            loader = M9ATaskLoader(root)
+
+            legacy_task.unlink()
+            self._write_task(root / "tasks", "new-task")
+            loader.reload()
+
+            self.assertEqual(loader.tasks_dir, root / "tasks")
+            self.assertEqual(loader.get_all_task_names(), ["new-task"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
M9A v4.5.0 将任务定义从 resource/tasks 移至根目录 tasks，旧后端因路径写死无法加载任务。本次同时兼容 tasks 与 resource/tasks，新路径优先，并在 reload 时重新探测以支持资源热更新。已通过 4 项单元测试，并使用 v4.5.0、v3.10.4 真实目录分别成功加载 25 个任务。

## Summary by Sourcery

为 M9A 添加动态任务目录解析机制，以同时支持旧版和新版目录布局，并确保与热更新资源兼容。

Bug Fixes:
- 修复当任务从 `resource/tasks` 移动到根级 `tasks` 目录后，M9A 任务加载失败的问题，通过在运行时同时解析这两种路径来解决。

Enhancements:
- 当同时存在旧版和新版任务目录布局时，优先使用新版任务目录，并在重新加载时重新检测当前使用的目录，以支持热更新。

Tests:
- 添加单元测试，覆盖从新版和旧版目录加载任务的场景、在两种目录同时存在时的优先级规则，以及通过重新加载检测目录变更的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add dynamic task directory resolution for M9A to support both legacy and new layouts and ensure compatibility with hot-updated resources.

Bug Fixes:
- Fix M9A task loading failure when tasks are moved from resource/tasks to the root-level tasks directory by resolving both paths at runtime.

Enhancements:
- Prefer the new tasks directory when both legacy and new task layouts are present and re-detect the active directory on reload to support hot updates.

Tests:
- Add unit tests covering task loading from new and legacy directories, preference rules when both exist, and directory changes detected via reload.

</details>