### PR TITLE
[Fix] 显示器变化后自动恢复屏幕外窗口

### DIFF
--- a/frontend/electron/main.ts
+++ b/frontend/electron/main.ts
@@ -10,6 +10,8 @@ import {
   screen,
   shell,
   Tray,
+  type Display,
+  type Rectangle,
 } from 'electron'
 import * as fs from 'fs'
 import * as path from 'path'
@@ -340,40 +342,100 @@ function updateTrayVisibility(config: AppConfig) {
 let mainWindow: Electron.BrowserWindow | null = null
 let logWindow: Electron.BrowserWindow | null = null
 
+const TITLE_BAR_HEIGHT = 32
+const RECOVERY_DRAG_HANDLE_WIDTH = 64
+
+function findDisplayWithUsableTitleBar(bounds: Rectangle): Display | undefined {
+  const handleWidth = Math.min(RECOVERY_DRAG_HANDLE_WIDTH, bounds.width)
+  const handleHeight = Math.min(TITLE_BAR_HEIGHT, bounds.height)
+
+  return screen.getAllDisplays().find(display => {
+    const workArea = display.workArea
+
+    return (
+      bounds.x >= workArea.x &&
+      bounds.y >= workArea.y &&
+      bounds.x + handleWidth <= workArea.x + workArea.width &&
+      bounds.y + handleHeight <= workArea.y + workArea.height
+    )
+  })
+}
+
+function centerBoundsInWorkArea(bounds: Rectangle, workArea: Rectangle): Rectangle {
+  const width = Math.min(bounds.width, workArea.width)
+  const height = Math.min(bounds.height, workArea.height)
+
+  return {
+    x: workArea.x + Math.floor((workArea.width - width) / 2),
+    y: workArea.y + Math.floor((workArea.height - height) / 2),
+    width,
+    height,
+  }
+}
+
+function parseConfigInteger(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value?.trim() ?? '', 10)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
 function createWindow() {
   logger.info('开始创建主窗口')
 
   const config = loadConfig()
 
   // 解析配置
-  const [cfgW, cfgH] = config.UI.size.split(',').map((s: string) => parseInt(s.trim(), 10) || 960)
-  const [cfgX, cfgY] = config.UI.location
-    .split(',')
-    .map((s: string) => parseInt(s.trim(), 10) || 100)
+  const [rawW, rawH] = (config.UI.size ?? defaultConfig.UI.size).split(',')
+  const [rawX, rawY] = (config.UI.location ?? defaultConfig.UI.location).split(',')
+  const parsedW = parseConfigInteger(rawW, 1600)
+  const parsedH = parseConfigInteger(rawH, 1000)
+  const cfgW = parsedW > 0 ? parsedW : 1600
+  const cfgH = parsedH > 0 ? parsedH : 1000
+  const cfgX = parseConfigInteger(rawX, 100)
+  const cfgY = parseConfigInteger(rawY, 100)
 
-  // 以目标位置选最近显示器
-  const targetDisplay = screen.getDisplayNearestPoint({ x: cfgX, y: cfgY })
+  const savedBounds = { x: cfgX, y: cfgY, width: cfgW, height: cfgH }
+  const savedDisplay = findDisplayWithUsableTitleBar(savedBounds)
+  const targetDisplay = savedDisplay ?? screen.getPrimaryDisplay()
   const sf = targetDisplay.scaleFactor
 
+  const { width: waW, height: waH } = targetDisplay.workArea
+
   // 逻辑最小尺寸（DIP）
-  const minDipW = Math.floor(960 / sf)
-  const minDipH = Math.floor(900 / sf)
+  const minDipW = Math.min(Math.floor(960 / sf), waW)
+  const minDipH = Math.min(Math.floor(900 / sf), waH)
 
   // 初始窗口逻辑尺寸（DIP）
   let initW = Math.max(cfgW, minDipW)
   let initH = Math.max(cfgH, minDipH)
 
   // 不超过工作区
-  const { width: waW, height: waH } = targetDisplay.workAreaSize
   initW = Math.min(initW, waW)
   initH = Math.min(initH, waH)
 
+  const candidateBounds = { x: cfgX, y: cfgY, width: initW, height: initH }
+  const candidateDisplay = findDisplayWithUsableTitleBar(candidateBounds)
+  const initialBounds = candidateDisplay
+    ? candidateBounds
+    : centerBoundsInWorkArea(candidateBounds, screen.getPrimaryDisplay().workArea)
+  const boundsWereAdjusted =
+    initialBounds.x !== savedBounds.x ||
+    initialBounds.y !== savedBounds.y ||
+    initialBounds.width !== savedBounds.width ||
+    initialBounds.height !== savedBounds.height
+
+  if (boundsWereAdjusted) {
+    config.UI.size = `${initialBounds.width},${initialBounds.height}`
+    config.UI.location = `${initialBounds.x},${initialBounds.y}`
+    saveConfig(config)
+    logger.warn('保存的窗口边界已调整到当前显示器的可见区域')
+  }
+
   // 关键：用局部常量 win，全程用它，类型不为 null
   const win = new BrowserWindow({
-    x: cfgX,
-    y: cfgY,
-    width: initW,
-    height: initH,
+    x: initialBounds.x,
+    y: initialBounds.y,
+    width: initialBounds.width,
+    height: initialBounds.height,
     minWidth: minDipW,
     minHeight: minDipH,
     useContentSize: true,
@@ -394,6 +456,20 @@ function createWindow() {
   // 把局部的 win 赋值给模块级（供其他模块/函数用）
   mainWindow = win
 
+  // Electron 在最大化窗口最小化后会让 isMaximized() 返回 false，单独记住恢复目标状态。
+  let restoreToMaximized = Boolean(config.UI.maximized)
+  win.on('maximize', () => {
+    restoreToMaximized = true
+  })
+  win.on('unmaximize', () => {
+    restoreToMaximized = false
+  })
+  win.on('restore', () => {
+    if (restoreToMaximized && !win.isMaximized()) {
+      win.maximize()
+    }
+  })
+
   // 页面加载完成后再显示窗口，避免白屏闪烁
   win.webContents.on('did-finish-load', () => {
     // 仅开机自启动且开启"启动后直接最小化"时才隐藏窗口，手动双击启动始终显示
@@ -406,32 +482,71 @@ function createWindow() {
   // 根据显示器动态更新最小尺寸/边界
   const recomputeMinSize = () => {
     // 这里用 win，不会是 null
-    const bounds = win.getBounds()
+    const isMinimized = win.isMinimized()
+    const bounds = isMinimized ? win.getNormalBounds() : win.getBounds()
     const disp = screen.getDisplayMatching(bounds)
     const s = disp.scaleFactor
-    const w = Math.floor(960 / s)
-    const h = Math.floor(900 / s)
+    const w = Math.min(Math.floor(960 / s), disp.workArea.width)
+    const h = Math.min(Math.floor(900 / s), disp.workArea.height)
 
     const [curMinW, curMinH] = win.getMinimumSize()
     if (w !== curMinW || h !== curMinH) {
       win.setMinimumSize(w, h)
+    }
 
-      if (win.isMaximized()) return
+    if (win.isMaximized() || isMinimized) return
 
-      const { width: wW, height: wH } = disp.workAreaSize
-      const newBounds = { ...bounds }
-      if (newBounds.width > wW) newBounds.width = wW
-      if (newBounds.height > wH) newBounds.height = wH
-      if (newBounds.width < w) newBounds.width = w
-      if (newBounds.height < h) newBounds.height = h
+    const { width: wW, height: wH } = disp.workArea
+    const newBounds = { ...bounds }
+    if (newBounds.width > wW) newBounds.width = wW
+    if (newBounds.height > wH) newBounds.height = wH
+    if (newBounds.width < w) newBounds.width = w
+    if (newBounds.height < h) newBounds.height = h
+
+    if (newBounds.width !== bounds.width || newBounds.height !== bounds.height) {
       win.setBounds(newBounds)
     }
+  }
+
+  const ensureWindowIsVisible = () => {
+    if (win.isDestroyed()) return
+
+    const wasMinimized = win.isMinimized()
+    const wasVisible = win.isVisible()
+    const wasMaximized = win.isMaximized() || (!wasVisible && restoreToMaximized)
+    const bounds = wasMaximized || wasMinimized ? win.getNormalBounds() : win.getBounds()
+    if (findDisplayWithUsableTitleBar(bounds)) return
+
+    const safeBounds = centerBoundsInWorkArea(bounds, screen.getPrimaryDisplay().workArea)
+
+    if (!wasMinimized && wasMaximized) win.unmaximize()
+    win.setBounds(safeBounds)
+    if (!wasMinimized && wasMaximized) {
+      if (wasVisible) {
+        win.maximize()
+      } else {
+        restoreToMaximized = true
+      }
+    }
+
+    const currentConfig = loadConfig()
+    currentConfig.UI.size = `${safeBounds.width},${safeBounds.height}`
+    currentConfig.UI.location = `${safeBounds.x},${safeBounds.y}`
+    currentConfig.UI.maximized = wasMaximized
+    saveConfig(currentConfig)
+    logger.warn('显示器布局发生变化，窗口已恢复到主显示器中央')
+  }
+
+  const handleDisplayConfigurationChanged = () => {
+    ensureWindowIsVisible()
+    recomputeMinSize()
   }
 
   // 监听显示器变化/窗口移动
   win.on('moved', recomputeMinSize)
   win.on('resized', recomputeMinSize)
-  screen.on('display-metrics-changed', recomputeMinSize)
+  screen.on('display-metrics-changed', handleDisplayConfigurationChanged)
+  screen.on('display-removed', handleDisplayConfigurationChanged)
 
   // 最大化配置
   if (config.UI.maximized) {
@@ -464,8 +579,10 @@ function createWindow() {
       if (!win.isDestroyed()) {
         try {
           const config = loadConfig()
-          const bounds = win.getBounds()
-          const isMaximized = win.isMaximized()
+          const isMinimized = win.isMinimized()
+          const bounds = isMinimized ? win.getNormalBounds() : win.getBounds()
+          const isMaximized =
+            !win.isVisible() || isMinimized ? restoreToMaximized : win.isMaximized()
 
           if (!isMaximized) {
             config.UI.size = `${bounds.width},${bounds.height}`
@@ -485,7 +602,8 @@ function createWindow() {
   win.on('closed', () => {
     logger.info('主窗口已关闭')
     // 清理监听（可选）
-    screen.removeListener('display-metrics-changed', recomputeMinSize)
+    screen.removeListener('display-metrics-changed', handleDisplayConfigurationChanged)
+    screen.removeListener('display-removed', handleDisplayConfigurationChanged)
     // 置空模块级引用
     mainWindow = null
 
@@ -514,6 +632,9 @@ function createWindow() {
   })
 
   win.on('show', () => {
+    if (restoreToMaximized && !win.isMaximized() && !win.isMinimized()) {
+      win.maximize()
+    }
     const currentConfig = loadConfig()
     win.setSkipTaskbar(false)
     updateTrayVisibility(currentConfig)
@@ -538,8 +659,10 @@ function createWindow() {
       if (win && !win.isDestroyed()) {
         try {
           const config = loadConfig()
-          const bounds = win.getBounds()
-          const isMaximized = win.isMaximized()
+          const isMinimized = win.isMinimized()
+          const bounds = isMinimized ? win.getNormalBounds() : win.getBounds()
+          const isMaximized =
+            !win.isVisible() || isMinimized ? restoreToMaximized : win.isMaximized()
 
           if (!isMaximized) {
             config.UI.size = `${bounds.width},${bounds.height}`

--- a/frontend/src/components/TitleBar.vue
+++ b/frontend/src/components/TitleBar.vue
@@ -257,7 +257,9 @@ onMounted(async () => {
   display: flex;
   align-items: center;
   padding-left: 12px;
+  min-width: 64px;
   height: 100%;
+  -webkit-app-region: drag;
 }
 
 .logo-section {
@@ -422,6 +424,7 @@ onMounted(async () => {
 .update-hint.clickable {
   cursor: pointer;
   user-select: none;
+  -webkit-app-region: no-drag;
 }
 
 .update-hint.clickable:hover {


### PR DESCRIPTION
## 修改内容

- 启动时校验标题栏左侧固定的 64px 恢复拖拽区是否仍完整位于任一显示器工作区内。
- 保存坐标失效时，将窗口收缩并居中恢复到主显示器，同时持久化修正后的 bounds。
- 监听显示器移除和指标变化，先恢复窗口位置，再按最终落点屏幕的 DPI 与工作区重算最小尺寸。
- 保留合法的负坐标与多显示器布局，不再把 `x = 0`、`y = 0` 误判为缺失配置。
- 为标题栏左侧定义稳定的恢复拖拽区，并保留更新提示的点击行为。
- 恢复时保留 normal、maximized、maximized → minimized 以及隐藏到托盘等窗口状态；隐藏窗口不会因显示器变化而意外弹出。

## 根因

原实现通过 `screen.getDisplayNearestPoint()` 选择缩放和工作区，但创建 `BrowserWindow` 时仍原样使用保存的 `cfgX/cfgY`。后续逻辑只调整宽高，不校验可拖拽区域是否可见，也没有处理 `display-removed`，因此断开副屏后窗口可以完全位于所有现存屏幕之外。

## 验证

- `yarn exec tsc -p tsconfig.electron.json --noEmit`：通过。
- `yarn exec eslint electron/main.ts src/components/TitleBar.vue`：通过。
- `git diff --check upstream/dev_v2...HEAD`：通过。
- 完整代码审查后无剩余 P1/P2 问题。

Closes #298

## Summary by Sourcery

确保在显示器变更时主窗口保持可见且尺寸正确，并持久化调整后的边界和状态。

Bug Fixes:
- 防止在移除显示器或显示参数变化后，主窗口完全移出屏幕之外。
- 在显示器变化和应用重启之间，正确保留窗口状态（正常、最大化、最小化、隐藏到托盘）。
- 避免将合法的负坐标或零坐标误判为缺失的配置值。

Enhancements:
- 基于每个显示器的工作区域和 DPI，对窗口边界和最小尺寸进行稳健处理，包括居中和限制在可用区域内。
- 优化窗口尺寸与位置的配置解析逻辑，提供合理默认值，并持久化修正后的边界。
- 稳定标题栏中的专用可拖拽区域，同时保留可点击的更新提示行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the main window remains visible and correctly sized when displays change, and persist adjusted bounds and state.

Bug Fixes:
- Prevent the main window from ending up completely off-screen after monitors are removed or display metrics change.
- Correctly preserve window state (normal, maximized, minimized, hidden to tray) across display changes and app restarts.
- Avoid misinterpreting valid negative or zero coordinates as missing configuration values.

Enhancements:
- Add robust handling for window bounds and minimum size based on per-display work areas and DPI, including centering and clamping within usable areas.
- Refine configuration parsing for window size and position with sensible defaults and persistence of corrected bounds.
- Stabilize a dedicated draggable area in the title bar while preserving clickable update hint behavior.

</details>