### PR TITLE
fix(MAAUserEdit): 修复关卡选择保存

### DIFF
--- a/frontend/src/views/EditView/User/MAAUserEdit.vue
+++ b/frontend/src/views/EditView/User/MAAUserEdit.vue
@@ -119,6 +119,8 @@ const formRef = ref<FormInstance>()
 const loading = computed(() => userLoading.value)
 const isInitializing = ref(true) // 标记是否正在初始化
 const isSaving = ref(false) // 标记是否正在保存
+const pendingFieldSaves = new Map<string, any>()
+let fieldSavePromise: Promise<void> | null = null
 
 // 路由参数
 const scriptId = route.params.scriptId as string
@@ -514,40 +516,63 @@ watch(
   }
 )
 
-// 即时保存单个字段变更
+// 即时保存单个字段变更。保存中的后续变更保留最后一次值，避免被 isSaving 直接丢弃。
 const handleFieldSave = async (key: string, value: any) => {
-  if (isInitializing.value || isSaving.value || !userId) return
+  if (isInitializing.value || !userId) return
 
-  isSaving.value = true
-  try {
-    // 解析 key 路径，例如 "Info.Status" -> { Info: { Status: value } }
-    const parts = key.split('.')
-    let userData: Record<string, any> = {}
-    let current = userData
+  pendingFieldSaves.set(key, value)
+  if (fieldSavePromise) return fieldSavePromise
 
-    for (let i = 0; i < parts.length - 1; i++) {
-      current[parts[i]] = {}
-      current = current[parts[i]]
+  const savePromise = (async () => {
+    isSaving.value = true
+    try {
+      while (pendingFieldSaves.size > 0) {
+        const pendingEntry = pendingFieldSaves.entries().next().value as
+          | [string, any]
+          | undefined
+        if (!pendingEntry) break
+
+        const [pendingKey, pendingValue] = pendingEntry
+        pendingFieldSaves.delete(pendingKey)
+
+        // 解析 key 路径，例如 "Info.Status" -> { Info: { Status: value } }
+        const parts = pendingKey.split('.')
+        let userData: Record<string, any> = {}
+        let current = userData
+
+        for (let i = 0; i < parts.length - 1; i++) {
+          current[parts[i]] = {}
+          current = current[parts[i]]
+        }
+        current[parts[parts.length - 1]] = pendingValue
+
+        // 特殊处理：userName 和 userId 需要同步到 Info
+        if (pendingKey === 'userName') {
+          userData = { Info: { Name: pendingValue } }
+        } else if (pendingKey === 'userId') {
+          userData = { Info: { Id: pendingValue } }
+        }
+
+        const success = await updateUser(scriptId, userId, userData)
+        if (!success) {
+          pendingFieldSaves.clear()
+          break
+        }
+
+        logger.info(`用户配置已保存: ${pendingKey}`)
+      }
+    } catch (error) {
+      pendingFieldSaves.clear()
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      logger.error(`保存失败: ${errorMsg}`)
+    } finally {
+      isSaving.value = false
+      fieldSavePromise = null
     }
-    current[parts[parts.length - 1]] = value
+  })()
+  fieldSavePromise = savePromise
 
-    // 特殊处理：userName 和 userId 需要同步到 Info
-    if (key === 'userName') {
-      userData = { Info: { Name: value } }
-    } else if (key === 'userId') {
-      userData = { Info: { Id: value } }
-    }
-
-    await updateUser(scriptId, userId, userData)
-    // 刷新数据
-    await loadUserData()
-    logger.info(`用户配置已保存: ${key}`)
-  } catch (error) {
-    const errorMsg = error instanceof Error ? error.message : String(error)
-    logger.error(`保存失败: ${errorMsg}`)
-  } finally {
-    isSaving.value = false
-  }
+  return savePromise
 }
 
 // 保存完整用户数据（仅用于特殊批量操作）
@@ -702,10 +727,17 @@ const loadStageOptions = async () => {
       type: GetStageIn.type.USER,
     })
     if (response && response.code === 200 && response.data) {
-      stageOptions.value = [...response.data].map(option => ({
+      const predefinedOptions = [...response.data].map(option => ({
         ...option,
         isCustom: false, // 明确标记从API加载的关卡为非自定义
       }))
+      const predefinedValues = new Set(predefinedOptions.map(option => option.value))
+      const customOptions = stageOptions.value.filter(
+        option => option.isCustom && !predefinedValues.has(option.value)
+      )
+
+      // 保留用户在选项请求完成前添加的自定义关卡，同时去掉竞态期间误判的标准关卡。
+      stageOptions.value = [...predefinedOptions, ...customOptions]
     }
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error)
@@ -969,6 +1001,15 @@ const validateStageName = (stageName: string): boolean => {
   return stagePattern.test(stageName.trim())
 }
 
+type StageField = 'Stage' | 'Stage_1' | 'Stage_2' | 'Stage_3' | 'Stage_Remain'
+
+const updateStageField = (field: StageField, value: string) => {
+  if (isPlanMode.value) return
+
+  formData.Info[field] = value
+  void handleFieldSave(`Info.${field}`, value)
+}
+
 // 添加自定义关卡到选项列表
 const addStageToOptions = (stageName: string) => {
   if (!stageName || !stageName.trim()) {
@@ -1003,9 +1044,7 @@ const addCustomStage = (stageName: string) => {
   }
 
   if (addStageToOptions(stageName)) {
-    if (!isPlanMode.value) {
-      formData.Info.Stage = stageName.trim()
-    }
+    updateStageField('Stage', stageName.trim())
   }
 }
 
@@ -1017,9 +1056,7 @@ const addCustomStage1 = (stageName: string) => {
   }
 
   if (addStageToOptions(stageName)) {
-    if (!isPlanMode.value) {
-      formData.Info.Stage_1 = stageName.trim()
-    }
+    updateStageField('Stage_1', stageName.trim())
   }
 }
 
@@ -1031,9 +1068,7 @@ const addCustomStage2 = (stageName: string) => {
   }
 
   if (addStageToOptions(stageName)) {
-    if (!isPlanMode.value) {
-      formData.Info.Stage_2 = stageName.trim()
-    }
+    updateStageField('Stage_2', stageName.trim())
   }
 }
 
@@ -1045,9 +1080,7 @@ const addCustomStage3 = (stageName: string) => {
   }
 
   if (addStageToOptions(stageName)) {
-    if (!isPlanMode.value) {
-      formData.Info.Stage_3 = stageName.trim()
-    }
+    updateStageField('Stage_3', stageName.trim())
   }
 }
 
@@ -1059,9 +1092,7 @@ const addCustomStageRemain = (stageName: string) => {
   }
 
   if (addStageToOptions(stageName)) {
-    if (!isPlanMode.value) {
-      formData.Info.Stage_Remain = stageName.trim()
-    }
+    updateStageField('Stage_Remain', stageName.trim())
   }
 }
 
@@ -1089,38 +1120,23 @@ const updateSeriesNumb = (value: string) => {
 }
 
 const updateStage = (value: string) => {
-  if (!isPlanMode.value) {
-    formData.Info.Stage = value
-    handleFieldSave('Info.Stage', value)
-  }
+  updateStageField('Stage', value)
 }
 
 const updateStage1 = (value: string) => {
-  if (!isPlanMode.value) {
-    formData.Info.Stage_1 = value
-    handleFieldSave('Info.Stage_1', value)
-  }
+  updateStageField('Stage_1', value)
 }
 
 const updateStage2 = (value: string) => {
-  if (!isPlanMode.value) {
-    formData.Info.Stage_2 = value
-    handleFieldSave('Info.Stage_2', value)
-  }
+  updateStageField('Stage_2', value)
 }
 
 const updateStage3 = (value: string) => {
-  if (!isPlanMode.value) {
-    formData.Info.Stage_3 = value
-    handleFieldSave('Info.Stage_3', value)
-  }
+  updateStageField('Stage_3', value)
 }
 
 const updateStageRemain = (value: string) => {
-  if (!isPlanMode.value) {
-    formData.Info.Stage_Remain = value
-    handleFieldSave('Info.Stage_Remain', value)
-  }
+  updateStageField('Stage_Remain', value)
 }
 
 // 初始化加载


### PR DESCRIPTION
## 变更

- 修复 MAA 用户编辑页切换标准关卡后未持久化的问题。
- 修复自定义关卡新增、选择后无法保存，重进页面后丢失的问题。
- 串行处理字段保存并保留最新值，避免保存中的更新被丢弃。
- 避免保存后重新加载旧数据，并合并初始化期间产生的自定义关卡选项。

## 根因

字段保存使用进行中标记直接跳过了后续更新；自定义关卡只更新了本地表单，没有统一走用户配置保存；关卡选项和用户数据并行加载时还可能覆盖本地自定义选项。

## 验证

- `yarn test`：12 个测试文件、44 个测试通过。
- `yarn vite build --outDir <isolated-output>`：通过。
- 目标文件语义 ESLint 检查：通过。
- 全量 typecheck/lint 仍受仓库既有无关错误影响，目标文件无对应报错。

## 由 Sourcery 提供的摘要

对每个字段的自动保存进行序列化和排队处理，确保阶段选择更改（包括自定义阶段）能够正确持久化，并且在初始化过程中不会被覆盖。

错误修复：
- 修复 MAA 用户编辑页面上标准阶段选择未持久化到用户配置中的问题。
- 修复新添加或选中的自定义阶段未被保存，并在重新进入页面后消失的问题。
- 防止在初始化期间远程加载的阶段选项覆盖本地添加的自定义阶段选项。

改进增强：
- 对待保存的字段进行排队和序列化处理，以在保存进行中不丢失更新，从而保留最新值。
- 通过共享的辅助函数统一阶段字段更新，以一致地更新表单数据，并在所有阶段字段中触发持久化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Serialize and queue per-field auto-saves and ensure stage selection changes, including custom stages, are correctly persisted without being overwritten during initialization.

Bug Fixes:
- Fix standard stage selection on the MAA user edit page not being persisted to the user configuration.
- Fix newly added or selected custom stages not being saved and disappearing after re-entering the page.
- Prevent remotely loaded stage options from overwriting locally added custom stage options during initialization.

Enhancements:
- Queue and serialize pending field saves to retain the latest value instead of dropping updates while a save is in progress.
- Unify stage field updates through a shared helper to consistently update form data and trigger persistence across all stage fields.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

对每个字段的自动保存进行序列化和排队处理，确保阶段选择更改（包括自定义阶段）能够正确持久化，并且在初始化过程中不会被覆盖。

错误修复：
- 修复 MAA 用户编辑页面上标准阶段选择未持久化到用户配置中的问题。
- 修复新添加或选中的自定义阶段未被保存，并在重新进入页面后消失的问题。
- 防止在初始化期间远程加载的阶段选项覆盖本地添加的自定义阶段选项。

改进增强：
- 对待保存的字段进行排队和序列化处理，以在保存进行中不丢失更新，从而保留最新值。
- 通过共享的辅助函数统一阶段字段更新，以一致地更新表单数据，并在所有阶段字段中触发持久化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Serialize and queue per-field auto-saves and ensure stage selection changes, including custom stages, are correctly persisted without being overwritten during initialization.

Bug Fixes:
- Fix standard stage selection on the MAA user edit page not being persisted to the user configuration.
- Fix newly added or selected custom stages not being saved and disappearing after re-entering the page.
- Prevent remotely loaded stage options from overwriting locally added custom stage options during initialization.

Enhancements:
- Queue and serialize pending field saves to retain the latest value instead of dropping updates while a save is in progress.
- Unify stage field updates through a shared helper to consistently update form data and trigger persistence across all stage fields.

</details>

</details>