### PR TITLE
fix(okww): 默认重试次数调整为 3 次

### DIFF
--- a/app/models/config.py
+++ b/app/models/config.py
@@ -2702,7 +2702,7 @@ class OkwwConfig(ConfigBase):
             "Run", "ProxyTimesLimit", 0, RangeValidator(0, 9999)
         )
         self.Run_RunTimesLimit = ConfigItem(
-            "Run", "RunTimesLimit", 1, RangeValidator(1, 9999)
+            "Run", "RunTimesLimit", 3, RangeValidator(1, 9999)
         )
         self.Run_RunTimeLimit = ConfigItem(
             "Run", "RunTimeLimit", 60, RangeValidator(1, 9999)

--- a/frontend/src/views/EditView/Script/OkwwScriptEdit.vue
+++ b/frontend/src/views/EditView/Script/OkwwScriptEdit.vue
@@ -363,7 +363,7 @@ const okwwConfig = reactive<OkwwScriptConfigForm>({
     Arguments: '',
     WaitTime: 60,
   },
-  Run: { ProxyTimesLimit: 0, RunTimesLimit: 1, RunTimeLimit: 60 },
+  Run: { ProxyTimesLimit: 0, RunTimesLimit: 3, RunTimeLimit: 60 },
 })
 
 const rules = {


### PR DESCRIPTION
- 将 Okww 的 `RunTimesLimit` 后端默认值从 1 调整为 3。
- 同步 Okww 编辑页初始化默认值，避免新配置显示与预期行为不一致。
- 已验证后端默认值读取与目标 Vue 文件 ESLint。

## Summary by Sourcery

调整 Okww 运行重试的默认值，并保持前端配置与后端行为一致。

Bug Fixes:
- 将 Okww 后端的 `RunTimesLimit` 默认值从 1 提升到 3，以符合预期的重试行为。
- 将 Okww 脚本编辑页面中初始的 `RunTimesLimit` 值与后端默认值对齐，避免 UI 默认值不一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust Okww run retry defaults and keep frontend configuration aligned with backend behavior.

Bug Fixes:
- Increase Okww RunTimesLimit backend default from 1 to 3 to match the intended retry behavior.
- Align Okww script edit page initial RunTimesLimit value with the backend default to avoid inconsistent UI defaults.

</details>