### PR TITLE
docs: 修复失效的 Star History 图表，切换至 star-history.dera.page

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ We thank the following contributors for their work on this project
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=AUTO-MAS-Project/AUTO-MAS&type=Date)](https://star-history.com/#AUTO-MAS-Project/AUTO-MAS&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=AUTO-MAS-Project/AUTO-MAS&type=Date)](https://star-history.dera.page/#AUTO-MAS-Project/AUTO-MAS&Date)
 
 ## 官方社区 / Official Community
 


### PR DESCRIPTION
README 中的 Star History 图表因 GitHub 星标 API 限制已无法正常渲染，显示为空白/损坏状态。
本 MR 将 Star History 图表地址切换至使用替代数据源、无需 API Token 的 star-history.dera.page，恢复图表的正常展示。

相关地址：https://github.com/Mubelotix/star-history

## Summary by Sourcery

文档：
- 将 README 中的 Star History 图表切换为使用 star-history.dera.page 服务，以恢复图表的正常渲染。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Switch the Star History chart in the README to the star-history.dera.page service to restore proper chart rendering.

</details>