### PR TITLE
ci(github workflows): 限制同步工作流仅在AUTO-MAS-Project组织下运行

### DIFF
--- a/.github/workflows/sync-cnb.yml
+++ b/.github/workflows/sync-cnb.yml
@@ -32,6 +32,7 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'AUTO-MAS-Project'
     steps:
       - uses: actions/checkout@v7.0.1
         with:


### PR DESCRIPTION
仅当仓库属于AUTO-MAS-Project组织时才触发同步工作流，避免外部仓库误触发执行

## Summary by Sourcery

Bug Fixes:
- 将 CNB 同步工作流限制为仅在 AUTO-MAS-Project 组织拥有的代码仓库中运行，防止在外部代码仓库中被意外触发执行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Restrict the CNB synchronization workflow to repositories owned by the AUTO-MAS-Project organization, preventing unintended execution in external repositories.

</details>