### PR TITLE
fix(MAA): 日志缺少「开始任务」行时仍能解析掉落统计

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -2631,6 +2631,22 @@ class AppConfig(GlobalConfig):
                 if end_index != -1:
                     fight_tasks.append((i, end_index))
 
+        # 兜底: 部分 MAA 版本只打印"完成任务", 不打印"开始任务"。
+        # 这种日志里掉落统计明明存在, 却因为找不到区间起点而被整段跳过,
+        # 导致 drop_statistics 恒为空。此时以上一个任务边界(或日志开头)
+        # 作为起点, 仍能正确取到该次作战的掉落。
+        if not fight_tasks:
+            prev_boundary = 0
+            for j, line in enumerate(logs):
+                if "完成任务: Fight" in line or "完成任务: 理智作战" in line:
+                    fight_tasks.append((prev_boundary, j))
+                if (
+                    "完成任务:" in line
+                    or "开始任务: Fight" in line
+                    or "开始任务: 理智作战" in line
+                ):
+                    prev_boundary = j
+
         # 处理每个Fight任务
         for start_idx, end_idx in fight_tasks:
             # 提取当前任务的日志


### PR DESCRIPTION
Closes #376

## 问题

`_save_maa_log` 里定位「理智作战」任务区间时，**必须先匹配到「开始任务」行**才会把区间记进 `fight_tasks`：

```python
for i, line in enumerate(logs):
    if "开始任务: Fight" in line or "开始任务: 理智作战" in line:
        ...
```

而部分 MAA 版本的日志里**只有「完成任务: 理智作战」，没有对应的「开始任务」行**。这种日志走下来 `fight_tasks` 为空，后面的掉落解析循环一次都不执行，于是 `drop_statistics` 恒为 `{}`——尽管日志里掉落统计完整地躺在那里。

## 两版真实日志对照

同一台机器、同一个账号、同样刷 TO-5：

| | 2026-08-17 的日志 | 2026-08-20 的日志 |
|---|---|---|
| `开始任务: 理智作战` | **0 次** | 1 次 |
| `完成任务: 理智作战` | 1 次 | 1 次 |
| 日志里有掉落统计 | 是 | 是 |
| 产出的 `drop_statistics` | **`{}`** | 正常 |

旧日志里掉落数据其实是全的：

```
[2026-08-17 09:07:34.053][INF][TaskQueueViewModel]     <2> TO-5 掉落统计:
龙门币 : 864 (+864)
沿途的点滴 : 72 (+72)
装置 : 4 (+4)
酮凝集 : 2 (+2)
```

## 改动

无「开始任务」行时，以**上一个任务边界**（或日志开头）作为区间起点。有「开始任务」行的日志完全走原路径，逻辑不变。改动 16 行，只加不删。

## 验证

用打过补丁的 `app/core/config.py` 里这段函数体，直接跑上面两份真实日志：

| 日志 | 改动前 | 改动后 |
|---|---|---|
| 旧格式（无「开始任务」行） | `{}` | `{'TO-5': {'龙门币': 864, '沿途的点滴': 72, '装置': 4, '酮凝集': 2}}` |
| 新格式（有「开始任务」行） | `{'TO-5': {'龙门币': 2448, ...}}` | **完全相同，无回归** |

数值与日志中最后一次掉落统计逐项吻合。

## 说明

- 这个改动由 AI 协助完成（分析、补丁、验证），提交前已用上述两份真实日志实测。如果维护者对某处实现有更合适的写法，我按建议改。
- 只覆盖了 `drop_statistics`。同一份旧日志里 `已确认招募` 也是 0 次、`recruit_statistics` 同样为空，看起来是相邻但独立的标记差异问题，本 PR 未一并处理，避免把范围扩大。

## Summary by Sourcery

Bug Fixes:
- 修复部分 MAA 日志缺少「开始任务」行时无法解析作战掉落统计的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 修复部分 MAA 日志缺少「开始任务」行时无法解析作战掉落统计的问题。

</details>